### PR TITLE
fix(worktree): scope lane permissions so worktree-lane agents cannot hang

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1145,6 +1145,7 @@ Extended worktree isolation configuration. These settings apply to all worktree 
 | `merge_strategy` | `"merge" \| "rebase" \| "cherry-pick"` | `"merge"` | Branch merge strategy after lane worktree completion. |
 | `worktree_dir` | string | _(none)_ | Optional user-specified worktree directory override. When set, worktrees are created under this path instead of the default `.swarm-worktrees/<sessionId>/<laneId>`. |
 | `deps_strategy` | `"skip" \| "copy" \| "link"` | `"skip"` | How to handle `node_modules` when provisioning a lane worktree. `"skip"` (default) does not copy — the lane runs without host packages. `"copy"` uses `cpSync` to duplicate `node_modules`. `"link"` creates symlinks (POSIX) or junctions (Windows). |
+| `lane_permissions` | `"scoped_allow" \| "deny" \| "off"` | `"scoped_allow"` | Permission policy for OpenCode instances running **inside** a worktree lane. See below. Has no effect outside a lane — ordinary sessions are never modified by this setting. |
 | `serialization_release_after_dispatches` | number | `5` | Release a serialized session after this many successful dispatches have completed and merged back from that session. Only applies when serialization mode is active. |
 | `serialization_release_after_ms` | number | `60000` | Release a serialized session after this many milliseconds have elapsed since the session was first serialized (even if zero dispatches have succeeded). Acts as a TTL ceiling on serialized sessions. |
 
@@ -1157,6 +1158,79 @@ Extended worktree isolation configuration. These settings apply to all worktree 
 | `"link"` | Creates symlinks (POSIX) or directory junctions (Windows). | Projects with many packages where copying is slow; requires filesystem support for symlinks. |
 
 > **Advisory for `deps_strategy: "skip"`:** When a task's gates include test/build commands and the lane was provisioned with `deps_strategy: "skip"`, the system emits a `WORKTREE_DEPS_SKIP` advisory suggesting to set `deps_strategy` to `"copy"` or `"link"` if the task requires host dependencies.
+
+#### `worktree.lane_permissions` — Permission policy inside a lane
+
+OpenCode partitions **all** permission state by directory. A worktree lane runs in its own OpenCode instance, so it starts with an empty `approved` list — every prior "Allow always" is forgotten — and a private pending-prompt map. Because no TUI is attached to a lane instance, an `external_directory` prompt raised there can never be answered, and the lane blocks indefinitely.
+
+This setting decides how that is resolved. It applies **only** inside a swarm worktree lane; every other session is left exactly as it is today.
+
+| Value | Behavior |
+|-------|----------|
+| `"scoped_allow"` (default) | Pre-grant `external_directory` access to a justified allowlist and deny everything else outright, so no request can be left pending. See the allowlist below. |
+| `"deny"` | Emit no allowlist — only the catch-all deny. Anything you have explicitly allowed in `permission.external_directory` still applies (your configuration is merged last and always wins), so this denies everything the plugin would otherwise have granted rather than literally every request. Still resolves rather than hanging. |
+| `"off"` | Apply no lane-specific rules. **This restores the hanging behavior described above** — an unanswerable prompt inside a lane will block that lane until the server is restarted. Provided only as an escape hatch. |
+
+Under `"scoped_allow"` the allowlist is:
+
+- the parent project the lane is a git worktree of, and the lane itself;
+- both OpenCode config directories — the XDG one (`~/.config/opencode`) and, when set, the `OPENCODE_CONFIG_DIR` override. OpenCode reads config from both, but does **not** base-allow either to an agent, so granting them is a deliberate widening (see the note below);
+- OpenCode's own temp directory (`<os-temp>/opencode`), and on Windows only the shortened-worktree lane root (`<os-temp>/swwt`) used by the path-budget fallback;
+- OpenCode's plan storage (`<data>/plans`), which the host natively allows to its built-in `plan` agent;
+- the skill roots OpenCode itself scans, mirroring its `{skill,skills}` glob (see the table below);
+- any directories listed in your `skills.paths` config, resolved the same way OpenCode resolves them (`~/` expands to your home directory, relative paths anchor to the lane).
+
+> **These are WRITE grants too.** OpenCode's `external_directory` permission has no read/write split, so every allowlist entry also permits writes. The list is deliberately narrow for that reason: the whole OS temp directory is **not** granted (only the two subtrees above), and neither are the opencode-swarm plugin cache/install locations — a lane writing to its own installed plugin would be executed in-process by the host on the next load. OpenCode's data directory is not granted either — only the `plans` subdirectory is, so session storage and the primary `auth.json` stay outside the grant. The user-level `~/.opencode` tree is deliberately **not** granted for the same reason: OpenCode's GitLab OAuth helper stores credentials at `~/.opencode/auth.json` when `XDG_DATA_HOME` is unset (the default on Windows and macOS). Its skill subdirectories (`~/.opencode/skill` and `~/.opencode/skills`) are granted individually instead. If a lane genuinely needs more of `~/.opencode`, add an explicit `permission.external_directory` allow — but be aware of what else lives there.
+
+Explicit configuration mostly wins: any `permission.external_directory` entry you set in `opencode.json` is merged **after** the generated rules, so your own `allow` and `deny` entries override both the allowlist and the catch-all deny.
+
+> **Known residual — a hand-made worktree at the exact lane path.** A worktree you create yourself at literally `<parent>/.swarm-worktrees/ses_<letters-and-digits>/<id>` is treated as a lane even on your own branch, and will get the scoped rules. This is accepted rather than fixed: it takes a deliberately lane-shaped directory name to reach, and the same leniency is what keeps a real lane recognised after you check out a different branch inside it. Use a directory name outside that shape, or set `worktree.lane_permissions: "off"`.
+
+> **Known narrowing — `references` directories.** OpenCode base-allows any directory listed in your top-level `references` config for every agent, but the plugin cannot resolve those paths from the config hook, so they are **not** re-granted inside a lane and a lane will be denied access to them. If you use `references`, add each directory explicitly: `{ "permission": { "external_directory": { "/path/to/reference/*": "allow" } } }`. The other families OpenCode base-allows for an agent — its own temp directory and the tool-output directory — are preserved inside a lane, as are the skill roots enumerated in the table below. The OpenCode config directories are granted as well; that one is a deliberate widening rather than a restoration, since OpenCode does not base-allow them to an agent. The user-level `~/.opencode` tree is **not** granted (only its skill subdirectories are) — see the write-grant note above.
+
+#### Skill roots reachable from a lane
+
+OpenCode discovers skills with two globs: `skills/**/SKILL.md` under `.claude` and `.agents` (plural only), and `{skill,skills}/**/SKILL.md` under each of its config directories (either spelling). The allowlist mirrors both, so every layout OpenCode supports stays reachable. Measured effective actions inside a lane under `scoped_allow`:
+
+| Skill layout | Action in a lane |
+|---|---|
+| `~/.claude/skills/<skill>` | allow |
+| `~/.agents/skills/<skill>` | allow |
+| `~/.opencode/skills/<skill>` | allow |
+| `~/.opencode/skill/<skill>` | allow |
+| `<xdg-config>/opencode/skill/<skill>` | allow |
+| `<project>/.claude/skills/<skill>` | allow |
+| `<project>/.agents/skills/<skill>` | allow |
+| `<project>/.opencode/{skill,skills}/<skill>` | allow |
+| `~/.opencode` (the tree itself) | **deny** |
+
+> **Not covered — `skills.urls`.** OpenCode pulls URL-sourced skills over the network into a cache directory the plugin cannot resolve without performing the pull itself, which is not permissible on the plugin-init path. If you use `skills.urls`, a lane will be denied access to the pulled content; add an explicit `permission.external_directory` allow for the cache location.
+
+> **Exception — `"ask"` becomes `"deny"` inside a lane.** A lane instance has no TUI attached, so an `ask` there is not a third policy choice; nothing can ever answer it, and the lane blocks forever. Any `external_directory` `"ask"` you configure — top level or per agent, string shorthand or pattern map — is therefore applied as `"deny"` inside a lane only, and the affected patterns are named in the advisory and in the `.swarm/events.jsonl` record. Use an explicit `"allow"` or `"deny"` to control the behavior, or `worktree.lane_permissions: "off"` if you really want the prompting (and hanging) restored. Outside a lane, `"ask"` is untouched.
+
+A denial cannot carry a message — a permission rule holds an action, not text. So when lane scoping activates, the plugin emits one advisory (visible via `/swarm diagnose`) and appends a `lane_permissions` record to `.swarm/events.jsonl` naming the lane, the parent project, the full allowlist with justifications, and the remedy below.
+
+**To widen the allowlist**, add the directory to `opencode.json`:
+
+```json
+{
+  "permission": {
+    "external_directory": {
+      "/absolute/path/to/dir/*": "allow"
+    }
+  }
+}
+```
+
+**Example** — deny all external directory access inside lanes:
+
+```json
+{
+  "worktree": {
+    "lane_permissions": "deny"
+  }
+}
+```
 
 #### `worktree.runtime_isolation` — Per-lane runtime isolation settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1178,7 +1178,8 @@ Under `"scoped_allow"` the allowlist is:
 - OpenCode's own temp directory (`<os-temp>/opencode`), and on Windows only the shortened-worktree lane root (`<os-temp>/swwt`) used by the path-budget fallback;
 - OpenCode's plan storage (`<data>/plans`), which the host natively allows to its built-in `plan` agent;
 - the skill roots OpenCode itself scans, mirroring its `{skill,skills}` glob (see the table below);
-- any directories listed in your `skills.paths` config, resolved the same way OpenCode resolves them (`~/` expands to your home directory, relative paths anchor to the lane).
+- any directories listed in your `skills.paths` config, resolved the same way OpenCode resolves them (`~/` expands to your home directory, relative paths anchor to the lane);
+- **only if you configure `skills.urls`**, the URL-skill cache root `$XDG_CACHE_HOME/opencode/skills` (default `~/.cache/opencode/skills`). With no `skills.urls` set, nothing under the cache is granted — see the note below.
 
 > **These are WRITE grants too.** OpenCode's `external_directory` permission has no read/write split, so every allowlist entry also permits writes. The list is deliberately narrow for that reason: the whole OS temp directory is **not** granted (only the two subtrees above), and neither are the opencode-swarm plugin cache/install locations — a lane writing to its own installed plugin would be executed in-process by the host on the next load. OpenCode's data directory is not granted either — only the `plans` subdirectory is, so session storage and the primary `auth.json` stay outside the grant. The user-level `~/.opencode` tree is deliberately **not** granted for the same reason: OpenCode's GitLab OAuth helper stores credentials at `~/.opencode/auth.json` when `XDG_DATA_HOME` is unset (the default on Windows and macOS). Its skill subdirectories (`~/.opencode/skill` and `~/.opencode/skills`) are granted individually instead. If a lane genuinely needs more of `~/.opencode`, add an explicit `permission.external_directory` allow — but be aware of what else lives there.
 
@@ -1202,9 +1203,15 @@ OpenCode discovers skills with two globs: `skills/**/SKILL.md` under `.claude` a
 | `<project>/.claude/skills/<skill>` | allow |
 | `<project>/.agents/skills/<skill>` | allow |
 | `<project>/.opencode/{skill,skills}/<skill>` | allow |
+| `$XDG_CACHE_HOME/opencode/skills/<skill>` (URL-sourced) | allow |
 | `~/.opencode` (the tree itself) | **deny** |
+| `$XDG_CACHE_HOME/opencode` (the cache parent) | **deny** |
 
-> **Not covered — `skills.urls`.** OpenCode pulls URL-sourced skills over the network into a cache directory the plugin cannot resolve without performing the pull itself, which is not permissible on the plugin-init path. If you use `skills.urls`, a lane will be denied access to the pulled content; add an explicit `permission.external_directory` allow for the cache location.
+> **`skills.urls` are covered — conditionally, and as a superset.** OpenCode pulls URL-sourced skills into `$XDG_CACHE_HOME/opencode/skills` (default `~/.cache/opencode/skills`) and adds each pulled skill's directory to the set it base-allows every agent, so a lane needs that root to read them. The grant is made **only when your config actually declares `skills.urls`** — otherwise nothing under the cache is base-allowed to an ordinary session either, and granting it would make a lane *more* permissive than a normal session.
+>
+> Note this is a **superset** of what OpenCode base-allows: the host allows each individual pulled directory, whereas the plugin grants the whole root (a rule pattern's `*` spans path separators). Because `external_directory` grants writes as well as reads, and OpenCode skips downloading a file whose destination already exists, a lane with this grant could pre-place content at a deterministic cache path that a later, different session would then load as skill instructions. That risk is accepted only when you have opted into `skills.urls`; set `worktree.lane_permissions: "deny"` if you would rather a lane never reach the cache.
+>
+> Only that subdirectory is granted — **not** the cache parent `$XDG_CACHE_HOME/opencode`, which contains `bin/`, a directory OpenCode executes from; granting the parent would place executable code inside a lane's write grant.
 
 > **Exception — `"ask"` becomes `"deny"` inside a lane.** A lane instance has no TUI attached, so an `ask` there is not a third policy choice; nothing can ever answer it, and the lane blocks forever. Any `external_directory` `"ask"` you configure — top level or per agent, string shorthand or pattern map — is therefore applied as `"deny"` inside a lane only, and the affected patterns are named in the advisory and in the `.swarm/events.jsonl` record. Use an explicit `"allow"` or `"deny"` to control the behavior, or `worktree.lane_permissions: "off"` if you really want the prompting (and hanging) restored. Outside a lane, `"ask"` is untouched.
 

--- a/docs/releases/pending/worktree-lane-permission-scoping.md
+++ b/docs/releases/pending/worktree-lane-permission-scoping.md
@@ -13,7 +13,9 @@ front instead of raising prompts that nothing can answer.
   directories the host reads (the XDG one and, when set, the `OPENCODE_CONFIG_DIR`
   override), OpenCode's own temp directory, OpenCode's plan storage
   (`<data>/plans`), on Windows the shortened-worktree lane root used by the
-  path-budget fallback, and the configured skill roots (`.opencode/skills`,
+  path-budget fallback, the URL-skill cache root
+  (`$XDG_CACHE_HOME/opencode/skills`, and only when `skills.urls` is
+  configured), and the configured skill roots (`.opencode/skills`,
   `.opencode/skills/generated`, `.claude/skills`) resolved against the parent
   project, the lane, and your home directory — and denies
   everything else outright, so no request can be left pending.
@@ -39,12 +41,21 @@ front instead of raising prompts that nothing can answer.
   | `<project>/.claude/skills/<skill>` | allow |
   | `<project>/.agents/skills/<skill>` | allow |
   | `<project>/.opencode/{skill,skills}/<skill>` | allow |
+  | `$XDG_CACHE_HOME/opencode/skills/<skill>` (URL-sourced) | allow |
   | `~/.opencode` (the tree itself) | **deny** |
+  | `$XDG_CACHE_HOME/opencode` (the cache parent) | **deny** |
 
   Directories listed in `skills.paths` are granted too, resolved exactly as
-  OpenCode resolves them. `skills.urls` are **not**: OpenCode pulls those over
-  the network into a cache the plugin cannot locate without performing the pull
-  itself, which the plugin-init path forbids.
+  OpenCode resolves them. URL-sourced skills (`skills.urls`) are covered too,
+  but conditionally and as a superset: OpenCode caches them under
+  `$XDG_CACHE_HOME/opencode/skills` and base-allows each pulled directory, so
+  the lane is granted that ROOT — and only when the config actually declares
+  `skills.urls`, since otherwise a lane would end up more permissive than an
+  ordinary session. Because the grant covers writes and OpenCode skips a
+  download whose destination exists, a lane could pre-place content a later
+  session would load as a skill; that is accepted only under an explicit
+  `skills.urls` opt-in. Never the cache parent, which holds the `bin/`
+  directory the host executes from.
 - Explicit configuration mostly wins: any `permission.external_directory` entry
   in `opencode.json` is merged after the generated rules and overrides both the
   allowlist and the catch-all deny. The one exception is `"ask"`, which is

--- a/docs/releases/pending/worktree-lane-permission-scoping.md
+++ b/docs/releases/pending/worktree-lane-permission-scoping.md
@@ -1,0 +1,160 @@
+# Worktree lanes no longer hang on unanswerable permission prompts
+
+## What
+
+Swarm worktree lanes now resolve their `external_directory` permissions up
+front instead of raising prompts that nothing can answer.
+
+- New `worktree.lane_permissions` setting: `"scoped_allow"` (default),
+  `"deny"`, or `"off"`.
+- Under `"scoped_allow"`, an OpenCode instance running inside a swarm worktree
+  lane pre-grants `external_directory` access to a justified allowlist — the
+  parent project the lane is a worktree of, the lane itself, both OpenCode config
+  directories the host reads (the XDG one and, when set, the `OPENCODE_CONFIG_DIR`
+  override), OpenCode's own temp directory, OpenCode's plan storage
+  (`<data>/plans`), on Windows the shortened-worktree lane root used by the
+  path-budget fallback, and the configured skill roots (`.opencode/skills`,
+  `.opencode/skills/generated`, `.claude/skills`) resolved against the parent
+  project, the lane, and your home directory — and denies
+  everything else outright, so no request can be left pending.
+- Because `external_directory` has no read/write split, every allowlist entry is
+  also a write grant. The list is deliberately narrow: the whole OS temp
+  directory is **not** granted, nor are the plugin cache/install locations, nor
+  OpenCode's data directory beyond its `plans` subdirectory. The user-level
+  `~/.opencode` tree is excluded specifically because OpenCode's GitLab OAuth
+  helper stores credentials at `~/.opencode/auth.json` when `XDG_DATA_HOME` is
+  unset (the default on Windows and macOS); its skill subdirectories (both the
+  `skill` and `skills` spellings OpenCode accepts) are granted individually
+  instead.
+- Skill roots mirror OpenCode's own discovery globs rather than a subset, so
+  every layout it supports stays reachable from a lane. Measured:
+
+  | Skill layout | Action in a lane |
+  |---|---|
+  | `~/.claude/skills/<skill>` | allow |
+  | `~/.agents/skills/<skill>` | allow |
+  | `~/.opencode/skills/<skill>` | allow |
+  | `~/.opencode/skill/<skill>` | allow |
+  | `<xdg-config>/opencode/skill/<skill>` | allow |
+  | `<project>/.claude/skills/<skill>` | allow |
+  | `<project>/.agents/skills/<skill>` | allow |
+  | `<project>/.opencode/{skill,skills}/<skill>` | allow |
+  | `~/.opencode` (the tree itself) | **deny** |
+
+  Directories listed in `skills.paths` are granted too, resolved exactly as
+  OpenCode resolves them. `skills.urls` are **not**: OpenCode pulls those over
+  the network into a cache the plugin cannot locate without performing the pull
+  itself, which the plugin-init path forbids.
+- Explicit configuration mostly wins: any `permission.external_directory` entry
+  in `opencode.json` is merged after the generated rules and overrides both the
+  allowlist and the catch-all deny. The one exception is `"ask"`, which is
+  applied as `"deny"` **inside a lane only** — top level or per agent, string
+  shorthand or pattern map. A lane has no TUI, so an `ask` there cannot be
+  answered by anyone and would hang the lane indefinitely; honouring it
+  literally would silently reinstate the very bug this change fixes. The
+  downgraded patterns are named in the advisory and the event record. Outside a
+  lane, `"ask"` is untouched.
+- Lane detection keys on the worktree's git BRANCH, not its path, so it also
+  covers lanes placed by a `worktree.worktree_dir` override and by the Windows
+  path-budget fallback (which relocates a lane to `<os-temp>/swwt/…` with no
+  user configuration). An OpenCode instance bound to a directory nested below a
+  lane root resolves to that lane root. The branch match is the COMPLETE grammar
+  (`swarm/<purpose>/<sessionId>/<id>` or `swarm-lane/<sessionId>/<id>`, with the
+  session segment constrained to OpenCode's `ses_…` form), not a `swarm/`
+  prefix — a hand-made `git worktree add -b swarm/my-experiment` is left
+  completely alone. The path fallback used for a detached HEAD is equally
+  tight: it requires the full provisioned shape
+  `<base>/.swarm-worktrees/<sessionId>/<id>`, so a hand-made worktree placed
+  inside `.swarm-worktrees` is also left alone.
+- Provisioning now REFUSES, with an actionable error, to create a lane whose
+  branch lane detection could not later recognise. A lane that cannot be
+  recognised is a lane that would hang, so an unrecognisable one is never
+  created — regardless of where its session id came from. `lean_turbo_run_phase`
+  and `epic_decide_phase` additionally prefer the real session id from the tool
+  context over the model-supplied argument, and reject an out-of-grammar id
+  up front.
+- A worktree you create yourself at exactly
+  `<parent>/.swarm-worktrees/ses_<letters-and-digits>/<id>` is treated as a lane
+  even on your own branch. This residual is accepted deliberately: it takes a
+  lane-shaped directory name to reach, and the same leniency keeps a real lane
+  recognised after you check out a different branch inside it.
+- Emitted rule patterns are canonicalised with a transcription of the host's own
+  `Filesystem.normalizePathPattern`, so a lane reached through a symlink or a
+  Windows junction still matches its own grant.
+- Because a permission rule carries an action and not a message, the plugin
+  emits one advisory (visible via `/swarm diagnose`) and appends a
+  `lane_permissions` record to `.swarm/events.jsonl` naming the lane, the parent
+  project, the full allowlist with justifications, and the exact `opencode.json`
+  edit that widens it.
+- A durable source-scanning guardrail now holds an exhaustive inventory of every
+  `session.create(` call site in `src/` together with the directory expression it
+  passes. Any new call site — or any change to an existing one's directory
+  expression — fails until a human classifies it, and foreign-directory sites
+  additionally require an explicit disposition.
+
+**Ordinary sessions are completely unaffected.** The rules apply only when the
+plugin's own directory resolves as a swarm worktree lane; otherwise the config
+object is not mutated at all.
+
+## Why
+
+OpenCode partitions **all** permission state by directory: `Permission.state`,
+`Agent.state`, `Plugin.state`, and `ToolRegistry.state` are each built through
+the same directory-keyed `InstanceState` cache. A swarm lane session is created
+against a new directory, so it starts with an empty `approved` list — every
+prior "Allow always" is forgotten — and a private pending-prompt map. No TUI is
+attached to a lane instance, so an `external_directory` prompt raised there can
+never be answered, and the host's `Permission.ask` awaits its deferred with no
+timeout. The lane blocks until the server restarts, while the user sees the same
+prompt reappear indefinitely.
+
+Pre-resolving the permission in config prevents the prompt from ever being
+raised, which is strictly better than answering it.
+
+## Migration
+
+No action required; the default preserves the intended behavior and fixes the
+hang.
+
+- If a lane legitimately needs a directory outside the allowlist, add it to
+  `opencode.json`:
+
+  ```json
+  { "permission": { "external_directory": { "/absolute/path/*": "allow" } } }
+  ```
+
+- `worktree.lane_permissions: "deny"` restricts a lane to its own worktree.
+- `worktree.lane_permissions: "off"` disables the feature and **restores the
+  previous hanging behavior**. It exists only as an escape hatch.
+
+## Caveats
+
+- The `permission.ask` plugin hook is **not** used, because it does not work.
+  It is declared in `@opencode-ai/plugin` and listed in the OpenCode binary's own
+  embedded documentation, but the shipped runtime (verified against opencode
+  1.18.10) never triggers it: `Plugin.trigger` dispatches by name lookup and
+  `permission.ask` is absent from the complete set of names it is called with,
+  and `Permission.ask` itself contains no plugin call. Registering the hook would
+  have been dead code, so the fix uses the `config` hook instead.
+- A deny cannot explain itself — the permission system stores an action, not
+  text. The explanation is therefore delivered out of band (advisory plus
+  `.swarm/events.jsonl`), not in the model-visible denial.
+- Sessions created against a foreign directory that is **not** a swarm worktree
+  lane are out of scope and unchanged: `src/evaluation/ephemeral-agent-dispatcher.ts`
+  reaches `os.tmpdir()` roots via `src/evaluation/runner.ts` and
+  `src/evaluation/gate-audit.ts`. Those can hang the same way, but applying lane
+  policy to a non-lane session would violate the requirement that ordinary
+  sessions are untouched. The gap is recorded, with evidence, in the new
+  guardrail's inventory so it cannot be forgotten.
+- One directory family that OpenCode base-allows for every agent is **not**
+  re-granted inside a lane: `config.references` directories, which the plugin
+  cannot resolve from the config hook. A lane will be denied access to them; add
+  an explicit `permission.external_directory` allow for each. The narrowing is
+  asserted in the test suite so it stays deliberate, and is documented in
+  `docs/configuration.md`. The other base-allowed families — OpenCode's temp
+  directory, the skill directories, and the tool-output directory — are
+  preserved. The OpenCode config directories are granted as well, but that
+  is a deliberate widening: OpenCode does not base-allow them for an agent.
+  OpenCode's plan storage (`<data>/plans`) is re-granted too — the host natively
+  allows it to the built-in `plan` agent, and the catch-all would otherwise
+  outrank that.

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -53,6 +53,21 @@ import { createTestEngineerAgent } from './test-engineer';
 
 export type { AgentDefinition } from './architect';
 
+/**
+ * Test-only dependency-injection seam. `getAgentConfigs` calls
+ * `_internals.createAgents(...)` instead of the module-local `createAgents`
+ * directly, so tests can substitute a synthetic agent set (e.g. a primary
+ * agent whose definition already declares a `permission` block) without
+ * `mock.module`, which leaks across files in Bun's shared test-runner
+ * process. Mutating this object is file-scoped and trivially restorable via
+ * `afterEach`.
+ */
+export const _internals: {
+	createAgents: typeof createAgents;
+} = {
+	createAgents,
+};
+
 // Track agents for which we've already warned about missing config
 const warnedAgents = new Set<string>();
 
@@ -1116,7 +1131,10 @@ export function getAgentConfigs(
 	sessionId?: string,
 	projectContext?: ProjectContext,
 ): Record<string, SDKAgentConfig> {
-	const agents = createAgents(config, projectContext ?? emptyProjectContext());
+	const agents = _internals.createAgents(
+		config,
+		projectContext ?? emptyProjectContext(),
+	);
 
 	// Check if tool filtering is disabled globally
 	const toolFilterEnabled = config?.tool_filter?.enabled ?? true;
@@ -1178,6 +1196,16 @@ export function getAgentConfigs(
 		}
 	}
 
+	// Narrows `agent.config.permission` to the SDK's declared permission
+	// shape, defensively rejecting absent values and non-object primitives
+	// (a malformed agent definition must not throw here). Mirrors the
+	// `isObjectRecord` convention used for config-hook guards in
+	// src/index.ts.
+	const isPermissionRecord = (
+		value: SDKAgentConfig['permission'],
+	): value is NonNullable<SDKAgentConfig['permission']> =>
+		typeof value === 'object' && value !== null;
+
 	const result = Object.fromEntries(
 		agents.map((agent) => {
 			const sdkConfig: SDKAgentConfig = {
@@ -1189,8 +1217,39 @@ export function getAgentConfigs(
 
 			if (isPrimaryAgent) {
 				sdkConfig.mode = 'primary';
-				// Allow task delegation for primary agents
-				(sdkConfig.permission as Record<string, 'allow'>) = { task: 'allow' };
+				// Allow task delegation for primary agents. Merge — never
+				// replace — the agent definition's own permission block.
+				// OpenCode merges agent-level permission additively on its
+				// side (rule evaluation uses `findLast` over concatenated
+				// permission entries), so wholesale replacement here was
+				// never necessary and previously discarded any edit/bash/
+				// webfetch/external_directory entries (including nested
+				// per-pattern objects, e.g. `external_directory: { "C:/foo/*":
+				// "allow" }`) the agent definition declared. `task: 'allow'`
+				// always wins when the definition also declares its own
+				// `task` entry — primary agents must always be able to
+				// delegate, which is the existing intent this branch
+				// preserves.
+				const existingPermission = isPermissionRecord(agent.config.permission)
+					? agent.config.permission
+					: undefined;
+				// POSITION IS PRECEDENCE. The host evaluates with `findLast` over
+				// `Object.entries` order and wildcard-matches the permission NAME,
+				// so `'*'` also matches `task`. A duplicate key in an object
+				// literal keeps its FIRST position and only takes the last value:
+				// `{ ...{ task: 'deny', '*': 'deny' }, task: 'allow' }` yields
+				// `{ task: 'allow', '*': 'deny' }` with `task` still at index 0, so
+				// `findLast` picks `'*': 'deny'` and the primary agent silently
+				// loses delegation — the opposite of the intent documented above.
+				// Delete-then-set moves `task` to the end so it genuinely wins.
+				const mergedPermission: NonNullable<SDKAgentConfig['permission']> & {
+					task: 'allow';
+				} = { ...existingPermission } as NonNullable<
+					SDKAgentConfig['permission']
+				> & { task: 'allow' };
+				delete (mergedPermission as Record<string, unknown>).task;
+				mergedPermission.task = 'allow';
+				sdkConfig.permission = mergedPermission;
 			} else {
 				sdkConfig.mode = 'subagent';
 			}

--- a/src/background/plan-sync-worker.ts
+++ b/src/background/plan-sync-worker.ts
@@ -271,6 +271,13 @@ export class PlanSyncWorker {
 			this.pollCheck();
 		}, this.pollIntervalMs);
 
+		// Never keep the process alive solely for this poll timer.
+		if (
+			typeof (this.pollTimer as { unref?: () => void }).unref === 'function'
+		) {
+			(this.pollTimer as { unref: () => void }).unref();
+		}
+
 		log('[PlanSyncWorker] Polling fallback established', {
 			intervalMs: this.pollIntervalMs,
 		});

--- a/src/background/pr-monitor-worker.ts
+++ b/src/background/pr-monitor-worker.ts
@@ -209,6 +209,13 @@ export class PrMonitorWorker {
 			});
 		}, this.config.poll_interval_seconds * 1000);
 
+		// Never keep the process alive solely for this poll timer.
+		if (
+			typeof (this.pollTimer as { unref?: () => void }).unref === 'function'
+		) {
+			(this.pollTimer as { unref: () => void }).unref();
+		}
+
 		this.status = 'running';
 		log('[PrMonitorWorker] Started polling', {
 			intervalSeconds: this.config.poll_interval_seconds,

--- a/src/commands/reset-session.ts
+++ b/src/commands/reset-session.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { SWARM_WORKTREE_DIR_NAME } from '../config/constants';
 import { clearTrajectoryStep } from '../hooks/trajectory-logger';
 import { validateSwarmPath } from '../hooks/utils';
 import { resetPrmSessionState } from '../prm';
@@ -144,7 +145,7 @@ export async function handleResetSessionCommand(
 	// Best-effort: clean stale worktree directories and orphan branches
 	const worktreesDir = path.resolve(
 		path.dirname(directory),
-		'.swarm-worktrees',
+		SWARM_WORKTREE_DIR_NAME,
 	);
 	try {
 		if (fs.existsSync(worktreesDir)) {

--- a/src/config/cache-paths.ts
+++ b/src/config/cache-paths.ts
@@ -80,6 +80,46 @@ export function getHostDataDir(): string {
 }
 
 /**
+ * The cache directory the OpenCode HOST uses (`Global.Path.cache`).
+ *
+ * Verbatim host source (opencode 1.18.10, offset 107378747):
+ *   `p = XDG_CACHE_HOME || join(homedir(), ".cache")`
+ *   `i = join(p, "opencode")`   -> `An.cache`
+ *
+ * Like `data`, there is no environment override beyond XDG.
+ *
+ * Not exported: the same object defines `bin: join(i, "bin")` — a directory the
+ * host creates at startup and EXECUTES from — so granting this directory
+ * wholesale would place executable code inside a write grant. Keeping it
+ * module-private means it cannot be imported and granted directly; callers take
+ * a specific subdirectory instead (see {@link getHostSkillCacheDir}).
+ *
+ * This is a speed bump, not a boundary: `getPluginCachePaths` and
+ * `getPluginLockFilePaths` below already inline the identical
+ * `XDG_CACHE_HOME || join(homedir(), '.cache')` expression, so the value is
+ * trivially reconstructible inside this file.
+ */
+function getHostCacheDir(): string {
+	const base = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+	return path.join(base, 'opencode');
+}
+
+/**
+ * Where OpenCode caches URL-sourced skills (`skills.urls`).
+ *
+ * Both discovery implementations agree on the root:
+ *   v1 (offset 102988349): `join(Global.Path.cache, "skills")`
+ *   v2 (offset 103375250): `resolve(cache, "skills", Bun.hash(url))` — a
+ *                          per-URL subdirectory of the same root.
+ *
+ * Pure path construction, no I/O and no network: the pull itself is the host's
+ * job, and the plugin only needs to know where the result lands.
+ */
+export function getHostSkillCacheDir(): string {
+	return path.join(getHostCacheDir(), 'skills');
+}
+
+/**
  * All known locations where OpenCode may cache the opencode-swarm plugin.
  * Order: newest/canonical first so status reporting shows the most relevant
  * path at the top.

--- a/src/config/cache-paths.ts
+++ b/src/config/cache-paths.ts
@@ -34,6 +34,52 @@ export function getPluginConfigDir(): string {
 }
 
 /**
+ * The config directory the OpenCode HOST is actually using, honouring
+ * `OPENCODE_CONFIG_DIR`.
+ *
+ * Verbatim host precedence (`C:\OpenCode\opencode.exe`, opencode 1.18.10,
+ * offset 107379448):
+ *
+ * ```js
+ * function y(N={}){return{home:G.home,data:G.data,cache:G.cache,
+ *   config:e.OPENCODE_CONFIG_DIR??G.config, ...}}
+ * ```
+ *
+ * This is deliberately SEPARATE from {@link getPluginConfigDir}, which has
+ * shared semantics relied on by `src/cli/index.ts` and
+ * `src/services/diagnose-service.ts` for locating plugin caches and lock files.
+ * Changing that function's meaning would move those consumers too.
+ *
+ * Only the worktree-lane permission allowlist uses this: under
+ * `OPENCODE_CONFIG_DIR` the two directories differ, and allowlisting the wrong
+ * one grants a directory the host is not reading while denying the one it is.
+ */
+export function getHostConfigDir(): string {
+	const override = process.env.OPENCODE_CONFIG_DIR;
+	if (override && override.trim() !== '') return override;
+	return getPluginConfigDir();
+}
+
+/**
+ * The data directory the OpenCode HOST uses.
+ *
+ * Verbatim host source (opencode 1.18.10, offset ~107378180):
+ *   `V = XDG_DATA_HOME || join(homedir(), ".local", "share")`
+ *   `U = join(V, "opencode")`   -> `Global.Path.data`
+ *
+ * Unlike `config`, the data path has no environment override: the `y()` service
+ * factory passes `data: G.data` straight through (offset 107379448).
+ *
+ * Used by the worktree-lane allowlist to re-grant `<data>/plans`, which the
+ * host natively allows to its `plan` agent.
+ */
+export function getHostDataDir(): string {
+	const base =
+		process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+	return path.join(base, 'opencode');
+}
+
+/**
  * All known locations where OpenCode may cache the opencode-swarm plugin.
  * Order: newest/canonical first so status reporting shows the most relevant
  * path at the top.

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -703,11 +703,31 @@ export const DEFAULT_LEAN_TURBO_CONFIG: LeanTurboConfig = {
 	},
 };
 
+/**
+ * Directory name of the DD-6 default swarm-managed worktree base, created as a
+ * SIBLING of the project root (`<project-parent>/.swarm-worktrees`).
+ *
+ * Single source of truth shared by `resolveWorktreeBaseDir` in
+ * `src/worktree/core.ts` (which BUILDS lane paths) and
+ * `src/config/lane-context.ts` (which RECOGNISES a lane path after the fact,
+ * from inside the lane's own OpenCode instance). Those two must never drift: if
+ * creation and recognition disagree, a lane instance silently fails to be
+ * identified as a lane and falls back to unscoped permission behaviour.
+ *
+ * It lives in this leaf constants module rather than in `src/worktree/core.ts`
+ * so that the init-path-safe lane modules can share it without pulling the
+ * worktree lifecycle module into the plugin entry's import graph
+ * (AGENTS.md invariant 1; enforced by
+ * `tests/unit/turbo/lean/init-safety.test.ts`).
+ */
+export const SWARM_WORKTREE_DIR_NAME = '.swarm-worktrees';
+
 export const DEFAULT_WORKTREE_ISOLATION_CONFIG: WorktreeIsolationConfig = {
 	policy: 'auto',
 	merge_strategy: 'merge',
 	worktree_dir: undefined,
 	deps_strategy: 'skip',
+	lane_permissions: 'scoped_allow',
 	serialization_release_after_dispatches: 5,
 	serialization_release_after_ms: 60_000,
 	runtime_isolation: {

--- a/src/config/host-path.ts
+++ b/src/config/host-path.ts
@@ -1,0 +1,131 @@
+/**
+ * Faithful transcription of OpenCode's path-canonicalisation helpers.
+ *
+ * ## Why this must exist
+ *
+ * The host asks for `external_directory` permission with a pattern it has run
+ * through `Filesystem.normalizePathPattern` — for example
+ * `src/tools/…` (offset 100715012):
+ *
+ * ```js
+ * let u = G.normalizePathPattern(Hr.join(y, "*"));
+ * yield* o.ask({ permission: "external_directory", patterns: [u], always: [u], … });
+ * ```
+ *
+ * Rule patterns from config get NO such treatment: `Permission.fromConfig`
+ * applies only `~` / `$HOME` expansion. So for a rule to match, its text must
+ * already equal what the host will produce for the asked path.
+ *
+ * That matters because `normalizePathPattern` resolves symlinks via
+ * `realpathSync.native`. A lane reached through a Windows junction (or a macOS
+ * `/var` → `/private/var` symlink) is asked for under its REAL path, while an
+ * un-canonicalised rule names the link path — so the lane is denied access to
+ * its own granted directory.
+ *
+ * Verbatim host source (`C:\OpenCode\opencode.exe`, opencode 1.18.10,
+ * offsets 107196170-107196420; the minified names resolve via the chunk's own
+ * imports at offset 107192671: `ky`=`path.resolve`, `yy`=`path.join`,
+ * `ek`=`fs.realpathSync`):
+ *
+ * ```js
+ * function j(F){ let z=ky(X(F)); try{ return ek.native(z) }catch{ return z } }
+ * YW.normalizePath = j;
+ *
+ * function J(F){
+ *   if(F==="*") return F;
+ *   let z=F.match(/^(.*)[\\/]\*$/);
+ *   if(!z) return j(F);
+ *   let Z=/^[A-Za-z]:$/.test(z[1]) ? z[1]+"\\" : z[1];
+ *   return yy(j(Z),"*");
+ * }
+ * YW.normalizePathPattern = J;
+ *
+ * function X(F){ return F
+ *   .replace(/^\/([a-zA-Z]):(?:[\\/]|$)/,(z,Z)=>`${Z.toUpperCase()}:/`)
+ *   .replace(/^\/([a-zA-Z])(?:\/|$)/,(z,Z)=>`${Z.toUpperCase()}:/`)
+ *   .replace(/^\/cygdrive\/([a-zA-Z])(?:\/|$)/,(z,Z)=>`${Z.toUpperCase()}:/`)
+ *   .replace(/^\/mnt\/([a-zA-Z])(?:\/|$)/,(z,Z)=>`${Z.toUpperCase()}:/`) }
+ * YW.windowsPath = X;
+ * ```
+ *
+ * If a future OpenCode release changes these, lane rules stop matching. The
+ * shared-normaliser tests in `tests/unit/config/lane-permissions.test.ts` are
+ * the tripwire — re-extract before "fixing" them.
+ *
+ * @module config/host-path
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Test-only DI seam (AGENTS.md invariant 7). Lets tests simulate a symlink /
+ * junction without creating one, and assert the ENOENT degradation.
+ */
+export const _internals = {
+	realpathSyncNative: fs.realpathSync.native as (p: string) => string,
+};
+
+/** Host `Filesystem.windowsPath`. */
+function hostWindowsPath(input: string): string {
+	return input
+		.replace(
+			/^\/([a-zA-Z]):(?:[\\/]|$)/,
+			(_m, d: string) => `${d.toUpperCase()}:/`,
+		)
+		.replace(/^\/([a-zA-Z])(?:\/|$)/, (_m, d: string) => `${d.toUpperCase()}:/`)
+		.replace(
+			/^\/cygdrive\/([a-zA-Z])(?:\/|$)/,
+			(_m, d: string) => `${d.toUpperCase()}:/`,
+		)
+		.replace(
+			/^\/mnt\/([a-zA-Z])(?:\/|$)/,
+			(_m, d: string) => `${d.toUpperCase()}:/`,
+		);
+}
+
+/**
+ * Host `Filesystem.normalizePath`: `realpathSync.native(path.resolve(windowsPath(p)))`,
+ * degrading to the un-realpath'd resolved form on ANY realpath failure.
+ *
+ * The host uses a bare `catch` here (not an ENOENT check), so a permission
+ * error degrades identically to a missing path. Transcribed as-is: diverging
+ * would make our rule text disagree with the host's asked text in exactly the
+ * cases where a lane is already having filesystem trouble.
+ */
+function hostNormalizePath(input: string): string {
+	const resolved = path.resolve(hostWindowsPath(input));
+	try {
+		return _internals.realpathSyncNative(resolved);
+	} catch {
+		// Bare catch, matching the host. The common case is a path that does not
+		// exist yet (e.g. a skill root the user has not created), but a
+		// permission error degrades the same way — deliberately, so both sides
+		// of the comparison stay in step.
+		return resolved;
+	}
+}
+
+/**
+ * Host `Filesystem.normalizePathPattern`.
+ *
+ * Canonicalises the DIRECTORY part of a `<dir>/*` pattern and re-appends the
+ * wildcard, leaving the bare `*` catch-all untouched. Note the drive-root
+ * special case: for `C:/*` the captured directory is `C:` which
+ * `path.resolve` would turn into the process's current directory on that
+ * drive, so the host appends a separator first.
+ */
+export function hostNormalizePathPattern(pattern: string): string {
+	if (pattern === '*') return pattern;
+	const match = /^(.*)[\\/]\*$/.exec(pattern);
+	if (!match) return hostNormalizePath(pattern);
+	const dir = /^[A-Za-z]:$/.test(match[1]) ? `${match[1]}\\` : match[1];
+	return path.join(hostNormalizePath(dir), '*');
+}
+
+/**
+ * Tier-0 test seam (writing-tests skill): pure transcriptions with no external
+ * dependency beyond the DI'd realpath. Only {@link hostNormalizePathPattern} is
+ * consumed by production code, so these stay internal.
+ */
+export const _test_exports = { hostWindowsPath, hostNormalizePath };

--- a/src/config/lane-context.ts
+++ b/src/config/lane-context.ts
@@ -1,0 +1,454 @@
+/**
+ * Swarm worktree-lane context detection.
+ *
+ * ## Why this exists
+ *
+ * OpenCode partitions **all** permission state by *directory*. Every service
+ * that matters — `Permission.state`, `Agent.state`, `Plugin.state`,
+ * `ToolRegistry.state` — is built through the same directory-keyed
+ * `InstanceState` cache. When opencode-swarm creates a worktree-lane session
+ * bound to a new directory (`session.create({ query: { directory: lanePath } })`),
+ * that lane gets a brand-new permission universe: an empty `approved` list, so
+ * every prior "Allow always" is forgotten, and a private pending map. Because a
+ * lane instance has no TUI attached, an `external_directory` prompt raised there
+ * can never be answered and the lane hangs forever (the host's `Permission.ask`
+ * awaits its deferred with no timeout).
+ *
+ * The fix is to pre-resolve permissions for lane instances via the plugin
+ * `config` hook. That requires answering one question cheaply and reliably:
+ * **is this directory a swarm worktree lane, and if so, what project is it a
+ * worktree of?**
+ *
+ * ## Why there is no `git` subprocess here
+ *
+ * The obvious implementation is
+ * `git -C <lane> rev-parse --path-format=absolute --git-common-dir`. This module
+ * deliberately does not do that. `resolveLaneContext` is called from the plugin
+ * `config` hook, which the host runs inside `Plugin.state` initialisation —
+ * squarely on the plugin-init path that AGENTS.md invariant 1 governs, and that
+ * invariant names Git commands explicitly as forbidden there.
+ *
+ * Instead this module reads the two files git itself would consult:
+ *
+ *   - `<lane>/.git` — in a linked worktree this is a *file*, not a directory,
+ *     containing `gitdir: <main>/.git/worktrees/<name>`.
+ *   - `<main>/.git/worktrees/<name>/commondir` — a relative pointer back to the
+ *     shared `.git` directory (normally `../..`).
+ *
+ * That is the same information the subprocess would return, obtained with at
+ * most two small synchronous reads, no child process, no timeout to get wrong,
+ * and nothing to kill in a `finally`. It is strictly safer on the init path than
+ * a spawn would be, and it removes an entire class of invariant-3 exposure.
+ *
+ * @module config/lane-context
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { addDeferredWarning } from '../services/warning-buffer';
+import { matchSwarmLaneBranch, matchSwarmLanePath } from './swarm-branch';
+
+/**
+ * A resolved swarm worktree lane.
+ */
+export interface LaneContext {
+	/** Absolute, resolved path of the lane worktree itself. */
+	lanePath: string;
+	/**
+	 * Absolute, resolved path of the project this lane is a git worktree of —
+	 * i.e. the main working tree that owns the shared `.git` directory.
+	 */
+	parentProjectPath: string;
+}
+
+/**
+ * Maximum number of directories held in the detection cache.
+ *
+ * AGENTS.md invariant 8: module-level state must be bounded with an explicit
+ * eviction strategy. Detection runs on hot paths (the `config` hook, and any
+ * future per-call consumer), and the key space is "directories OpenCode has
+ * opened an instance for" — small in practice, but not provably so across a
+ * long-lived server that opens many lanes.
+ */
+const MAX_CACHED_DIRECTORIES = 256;
+
+/**
+ * Resolved-directory -> detection result. `null` is a real, cached answer
+ * ("not a lane"), which is the common case and the one most worth caching.
+ */
+const laneContextCache = new Map<string, LaneContext | null>();
+
+/**
+ * Test-only dependency-injection seam (AGENTS.md invariant 7 — prefer
+ * `_internals` over `mock.module`, which leaks across files in Bun's shared
+ * test-runner process). Tests replace these to simulate unreadable `.git`
+ * files, malformed pointers, and permission errors. Restore in `afterEach`.
+ */
+export const _internals = {
+	readFileSync: fs.readFileSync as (p: string, enc: BufferEncoding) => string,
+	statSync: fs.statSync as (p: string) => { isFile(): boolean },
+	addDeferredWarning,
+	/**
+	 * Clears the detection cache. Test-only; production has no reason to call
+	 * it because a directory's lane-ness cannot change while the process holds
+	 * an OpenCode instance for that directory.
+	 */
+	clearCache: (): void => {
+		laneContextCache.clear();
+	},
+};
+
+/**
+ * Hard cap on the ancestor walk that locates a lane root from a nested
+ * instance directory. Bounds the work on the plugin-init path and terminates
+ * even if `path.dirname` never reaches a fixed point on some exotic path.
+ */
+const MAX_ANCESTOR_WALK_DEPTH = 40;
+
+/**
+ * Bounded retry for the detection I/O.
+ *
+ * `applyLanePermissions` is called exactly once per instance from the plugin
+ * `config` hook, so a transient failure has no second chance: the lane simply
+ * reverts to unscoped permissions, i.e. the original unbounded-prompt hang.
+ * `EMFILE` is entirely plausible under the normal swarm workload, where many
+ * lanes spawn at once.
+ *
+ * Cost is paid only on the ERROR path. The nominal bound is
+ * (MAX_DETECTION_ATTEMPTS - 1) * DETECTION_RETRY_BACKOFF_MS = 10 ms, but the
+ * REAL bound is platform-dependent: `Atomics.wait` inherits the OS timer
+ * granularity, and on Windows (~15.6 ms) a 5 ms request measures 14.8 ms
+ * average / 16.0 ms max, giving a worst case of ~32 ms for two backoffs.
+ * Measured on win32; Linux/macOS granularity is finer so the real bound there
+ * should be nearer the nominal 10 ms, but that is UNMEASURED. ~32 ms against
+ * the ~400 ms init deadline is acceptable, and this number is the whole
+ * justification for putting a thread-blocking wait on the init path, so it is
+ * stated as measured rather than as arithmetic.
+ *
+ * NOT fail-closed: an exhausted retry still reports "not a lane". Treating an
+ * I/O failure as "this IS a lane" would inject deny rules into ordinary
+ * sessions — the false-positive class that took three review rounds to
+ * eliminate. Retry, then warn.
+ */
+const MAX_DETECTION_ATTEMPTS = 3;
+const DETECTION_RETRY_BACKOFF_MS = 5;
+
+/**
+ * Synchronous sleep. `resolveLaneContext` is sync (the host's `config` hook
+ * mutates a shared object and cannot be made async here), so `Atomics.wait` is
+ * used rather than a spin loop: it blocks without burning CPU, and only ever
+ * runs after an I/O error.
+ */
+function sleepSync(ms: number): void {
+	try {
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+	} catch {
+		// SharedArrayBuffer unavailable — skip the backoff, still bounded.
+	}
+}
+
+/**
+ * Records a NEGATIVE detection result, but only when it is a real answer.
+ *
+ * A transient `EACCES` / `EMFILE` / `EBUSY` while reading git metadata is not
+ * evidence that a directory is "not a lane". Caching that would poison the
+ * directory for the entire process lifetime, silently disabling lane permission
+ * scoping. So an I/O failure is never cached — but note that on the production
+ * path `applyLanePermissions` runs exactly ONCE per instance from the config
+ * hook, so "not cached" does not mean "retried later": there is no later call.
+ * {@link resolveLaneContext} therefore retries in-line before giving up, and
+ * this function reports the exhausted case.
+ *
+ * The warning fires on ANY I/O failure, not only when the path carries a
+ * `.swarm-worktrees` segment. Gating it on that heuristic meant the layouts the
+ * heuristic cannot see — a `worktree_dir` override and the Windows `swwt`
+ * fallback — got no warning at all, which are precisely the cases most likely
+ * to matter.
+ */
+function remember(
+	key: string,
+	value: null,
+	io: { failed: boolean },
+): LaneContext | null {
+	if (!io.failed) return cache(key, value);
+	try {
+		_internals.addDeferredWarning(
+			`[swarm] Could not read git metadata for ${key} after ${MAX_DETECTION_ATTEMPTS} attempts; worktree-lane permission scoping was skipped for it. If this directory IS a swarm lane, external-directory prompts raised there cannot be answered and the lane may hang. Check filesystem permissions and open-file limits, then restart the session.`,
+		);
+	} catch {
+		// Advisory delivery must never break detection.
+	}
+	return null;
+}
+
+function cache(key: string, value: LaneContext | null): LaneContext | null {
+	// FIFO eviction — Map preserves insertion order, so the first key is the
+	// oldest. Evict before insert so the map never exceeds the cap.
+	if (laneContextCache.size >= MAX_CACHED_DIRECTORIES) {
+		const oldest = laneContextCache.keys().next();
+		if (!oldest.done) laneContextCache.delete(oldest.value);
+	}
+	laneContextCache.set(key, value);
+	return value;
+}
+
+/**
+ * PRIMARY ownership signal: reads `<gitDir>/HEAD` and reports whether the
+ * worktree is checked out on a branch this project's `makeWorktreeBranchName`
+ * produces.
+ *
+ * The worktree PATH is not a reliable marker. `provisionWorktree` can place a
+ * lane in any of three layouts, and only the first contains
+ * `.swarm-worktrees`:
+ *
+ *   1. `<project-parent>/.swarm-worktrees/<sessionId>/<id>` (DD-6 default)
+ *   2. `path.resolve(directory, worktree.worktree_dir)` (configured override)
+ *   3. `<os.tmpdir()>/swwt/<sessionId>/<laneId>` — the Windows path-budget
+ *      fallback in `shortenWorktreePath()`, which fires with NO user
+ *      configuration whenever the default path would exceed the 250-char
+ *      budget. Windows is precisely where this defect was reported.
+ *
+ * The branch name is invariant across all three, and is a single cheap read of
+ * a file git maintains.
+ */
+function isSwarmOwnedBranch(gitDir: string, io: { failed: boolean }): boolean {
+	let head: string;
+	try {
+		head = _internals.readFileSync(path.join(gitDir, 'HEAD'), 'utf-8');
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') io.failed = true;
+		return false;
+	}
+	// `ref: refs/heads/<branch>`. A detached HEAD holds a bare SHA and yields
+	// no branch, which correctly reports "unknown ownership" and defers to the
+	// secondary path signal.
+	const match = /^\s*ref:\s*refs\/heads\/(.+?)\s*$/m.exec(head);
+	const branch = match?.[1];
+	if (!branch) return false;
+	// Full-grammar match, NOT a prefix test: a user-authored branch such as
+	// `swarm/my-own-experiment` must not be mistaken for a lane.
+	return matchSwarmLaneBranch(branch) !== undefined;
+}
+
+/**
+ * Reads `<directory>/.git` when it is a *file* (the linked-worktree shape) and
+ * returns the absolute git directory it points at, or `undefined`.
+ *
+ * A `.git` *directory* means this is a main working tree, not a linked
+ * worktree — which is a legitimate "not a lane" answer, not an error.
+ */
+function readLinkedWorktreeGitDir(
+	directory: string,
+	io: { failed: boolean },
+): string | undefined {
+	const dotGit = path.join(directory, '.git');
+	let stat: { isFile(): boolean };
+	try {
+		stat = _internals.statSync(dotGit);
+	} catch (err) {
+		// ENOENT is a real answer ("no .git here"); anything else is an I/O
+		// failure whose result must NOT be cached as a negative — see the
+		// `io.failed` handling in resolveLaneContext.
+		if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') io.failed = true;
+		return undefined;
+	}
+	if (!stat.isFile()) return undefined;
+
+	let contents: string;
+	try {
+		contents = _internals.readFileSync(dotGit, 'utf-8');
+	} catch (err) {
+		// The `.git` file demonstrably exists (statSync succeeded), so failing to
+		// read it is always an I/O problem, never "not a lane".
+		if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') io.failed = true;
+		return undefined;
+	}
+
+	// Format: `gitdir: <path>` on the first line. The path may be absolute or
+	// relative to the worktree, and git writes forward slashes even on Windows.
+	const match = /^\s*gitdir:\s*(.+?)\s*$/m.exec(contents);
+	const pointer = match?.[1];
+	if (!pointer) return undefined;
+	// path.resolve keeps an absolute pointer as-is and anchors a relative one
+	// to the worktree, matching git's own interpretation.
+	return path.resolve(directory, pointer);
+}
+
+/**
+ * Resolves the main working tree that owns `gitDir`
+ * (`<main>/.git/worktrees/<name>`).
+ *
+ * Prefers the `commondir` file, which git maintains as the authoritative
+ * pointer to the shared `.git` directory and which stays correct even if the
+ * administrative layout changes. Falls back to the documented layout when
+ * `commondir` is absent or unreadable.
+ */
+function resolveMainWorktree(
+	gitDir: string,
+	io: { failed: boolean },
+): string | undefined {
+	let commonDir: string | undefined;
+	try {
+		const raw = _internals.readFileSync(
+			path.join(gitDir, 'commondir'),
+			'utf-8',
+		);
+		const trimmed = raw.trim();
+		if (trimmed) commonDir = path.resolve(gitDir, trimmed);
+	} catch (err) {
+		// A missing commondir is normal for older layouts — fall through to the
+		// documented `.git/worktrees/<n>` shape. Any OTHER error is real I/O
+		// trouble and must not be cached as a negative.
+		if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') io.failed = true;
+	}
+
+	if (commonDir) {
+		// commondir points at the shared `.git`; its parent is the main worktree.
+		const parent = path.dirname(commonDir);
+		return parent && parent !== commonDir ? parent : undefined;
+	}
+
+	// Fallback: `<main>/.git/worktrees/<name>` -> strip `<name>`, `worktrees`,
+	// `.git`. Verify the shape rather than blindly slicing three levels, so a
+	// non-conforming pointer yields "not a lane" instead of a wrong parent.
+	const worktreesDir = path.dirname(gitDir);
+	if (path.basename(worktreesDir) !== 'worktrees') return undefined;
+	const sharedGitDir = path.dirname(worktreesDir);
+	if (path.basename(sharedGitDir) !== '.git') return undefined;
+	const parent = path.dirname(sharedGitDir);
+	return parent && parent !== sharedGitDir ? parent : undefined;
+}
+
+/**
+ * Decides whether `directory` is a swarm worktree lane and, if so, resolves the
+ * lane path and the parent project it is a worktree of.
+ *
+ * Detection requires two independent conditions, the second of which may be
+ * satisfied either way:
+ *
+ *  1. REQUIRED — the directory (or a bounded number of its ancestors) is a real
+ *     LINKED git worktree whose main working tree resolves. A main working tree
+ *     has a `.git` directory rather than a file and is never a lane.
+ *  2. REQUIRED — the worktree is swarm-OWNED, established by EITHER
+ *     (a) its branch matching the full grammar in `./swarm-branch.ts`
+ *         (`swarm/<purpose>/<sessionId>/<id>` or `swarm-lane/<sessionId>/<id>`,
+ *         with `<sessionId>` of the form `ses_…`) — the authoritative,
+ *         path-independent signal; OR
+ *     (b) the path sitting under a `.swarm-worktrees` base — the fallback for a
+ *         worktree whose HEAD is detached or unreadable, so its branch cannot
+ *         be consulted.
+ *
+ * (2a) is a full-grammar match rather than a `swarm/` prefix test on purpose: a
+ * user-authored `swarm/my-own-experiment` worktree must NOT be captured. A
+ * false positive is worse than a false negative here — see the module note in
+ * `./swarm-branch.ts`.
+ *
+ * A detached-HEAD swarm lane created OUTSIDE `.swarm-worktrees` (a
+ * `worktree_dir` override, or the Windows path-budget fallback) satisfies
+ * neither branch of (2) and is a false NEGATIVE: no permission changes, i.e.
+ * today's behaviour. That is the safe direction and is left as-is.
+ *
+ * NEVER throws. Any error — nonexistent directory, unreadable `.git`, malformed
+ * pointer, permission error, non-string input — yields `null` ("not a lane"),
+ * which preserves today's behaviour for ordinary sessions. That direction is
+ * the safe one: a false negative means "no permission changes at all", while a
+ * false positive would apply a deny-by-default ruleset to a normal project.
+ *
+ * @param directory - Directory to classify (typically the plugin's own
+ *                    `ctx.directory`, which under this host IS the instance
+ *                    directory).
+ * @returns The resolved lane context, or `null` when `directory` is not a lane.
+ */
+export function resolveLaneContext(directory: string): LaneContext | null {
+	if (typeof directory !== 'string' || directory.trim() === '') return null;
+
+	let resolved: string;
+	try {
+		resolved = path.resolve(directory);
+	} catch {
+		return null;
+	}
+
+	const cached = laneContextCache.get(resolved);
+	if (cached !== undefined) return cached;
+
+	// Bounded retry: a transient I/O failure must not silently downgrade a real
+	// lane to "unscoped" — there is no second call on the production path.
+	let io = { failed: false };
+	let result: LaneContext | null = null;
+	for (let attempt = 1; attempt <= MAX_DETECTION_ATTEMPTS; attempt += 1) {
+		io = { failed: false };
+		result = attemptDetection(resolved, io);
+		// Success, or a definitive negative (no I/O trouble) — done either way.
+		if (result !== null || !io.failed) break;
+		if (attempt < MAX_DETECTION_ATTEMPTS) sleepSync(DETECTION_RETRY_BACKOFF_MS);
+	}
+	if (result !== null) return cache(resolved, result);
+	return remember(resolved, null, io);
+}
+
+/**
+ * One detection attempt. Returns the lane context, or `null` with `io.failed`
+ * set when the negative was caused by an I/O error rather than by a real
+ * answer.
+ */
+function attemptDetection(
+	resolved: string,
+	io: { failed: boolean },
+): LaneContext | null {
+	try {
+		// Signal 1 (required): find the nearest ancestor (including `resolved`
+		// itself) that is a real LINKED git worktree. A main working tree has a
+		// `.git` DIRECTORY, not a file, and is never a lane.
+		//
+		// The walk exists because an OpenCode instance can be bound to a
+		// directory NESTED below a lane root, which has no `.git` of its own; it
+		// still shares the lane's permission universe and must classify the same
+		// way.
+		let laneRoot: string | undefined;
+		let gitDir: string | undefined;
+		let current = resolved;
+		for (let depth = 0; depth < MAX_ANCESTOR_WALK_DEPTH; depth += 1) {
+			const candidate = readLinkedWorktreeGitDir(current, io);
+			if (candidate) {
+				laneRoot = current;
+				gitDir = candidate;
+				break;
+			}
+			const parent = path.dirname(current);
+			// `path.dirname` is idempotent at a filesystem root.
+			if (parent === current) break;
+			current = parent;
+		}
+		if (!laneRoot || !gitDir) return null;
+
+		// Signal 2 (required): the worktree must be swarm-owned. Branch name is
+		// authoritative and path-independent; the `.swarm-worktrees` path
+		// segment is the fallback for a detached or unreadable HEAD.
+		const swarmOwned =
+			isSwarmOwnedBranch(gitDir, io) ||
+			matchSwarmLanePath(laneRoot) !== undefined;
+		if (!swarmOwned) return null;
+
+		const parentProjectPath = resolveMainWorktree(gitDir, io);
+		if (!parentProjectPath) return null;
+
+		// A lane must not resolve to itself as its own parent; that would mean
+		// the git metadata is inconsistent and any allowlist built from it would
+		// be meaningless.
+		if (path.resolve(parentProjectPath) === laneRoot) {
+			return null;
+		}
+
+		return {
+			lanePath: laneRoot,
+			parentProjectPath: path.resolve(parentProjectPath),
+		};
+	} catch {
+		// Belt-and-braces: the helpers above already swallow their own I/O
+		// errors, but detection must be total. Any unexpected throw degrades to
+		// "not a lane" rather than propagating into the host's init path.
+		io.failed = true;
+		return null;
+	}
+}

--- a/src/config/lane-permissions.ts
+++ b/src/config/lane-permissions.ts
@@ -105,6 +105,7 @@ import { addDeferredWarning } from '../services/warning-buffer';
 import {
 	getHostConfigDir,
 	getHostDataDir,
+	getHostSkillCacheDir,
 	getPluginConfigDir,
 } from './cache-paths';
 import { hostNormalizePathPattern } from './host-path';
@@ -301,6 +302,7 @@ function push(
 function buildLaneAllowlist(
 	lane: LaneContext,
 	configuredSkillPaths: readonly string[] = [],
+	configuredSkillUrls: readonly string[] = [],
 ): LaneAllowlistEntry[] {
 	const out: LaneAllowlistEntry[] = [];
 	const seen = new Set<string>();
@@ -535,11 +537,71 @@ function buildLaneAllowlist(
 	//     `isDir`-checks each one; we deliberately do not, because granting a
 	//     path that does not exist yet is harmless and a stat per entry is not.
 	//
-	//     `skills.urls` are NOT granted: the host pulls them over the network
-	//     into a cache directory this hook cannot resolve without doing the pull
-	//     itself. Disclosed in docs/configuration.md.
+	//     `skills.urls` themselves need no per-URL handling here — their cache
+	//     root is granted below.
+
+	// (e) The URL-skill cache root. A SCOPED SUPERSET of the host's base allow —
+	//     NOT a pure restoration like <data>/plans, and deliberately conditional.
+	//
+	//     WHY IT IS NEEDED: when `skills.urls` is configured, the host pulls each
+	//     one and adds every pulled skill's directory to `Skill.dirs()` (offset
+	//     ~102994300: the `skills.urls` loop calls the same `u()` helper, which
+	//     does `dirs.add(dirname(match))`), and `Skill.dirs()` is part of the
+	//     per-agent base allow (Agent.state, offset 100811506). Without this a
+	//     lane would be denied a URL-sourced skill an ordinary session can read.
+	//
+	//     WHY IT IS CONDITIONAL: with no `skills.urls`, nothing under the cache
+	//     is in `Skill.dirs()`, so an ordinary session evaluates this path under
+	//     the base `"*": "ask"`. Granting it unconditionally would make a LANE
+	//     more permissive than an ordinary session — inverting the property this
+	//     whole module exists to preserve. So it is granted only when the config
+	//     actually declares URLs. Reading them is a pure property access on the
+	//     config object the hook already holds: no I/O, no network.
+	//
+	//     WHY IT IS A SUPERSET: the host base-allows `join(n,"*")` per INDIVIDUAL
+	//     pulled directory; we grant the ROOT, and `*` compiles to `.*` under the
+	//     `s` flag, so it covers the whole subtree — including hashed directories
+	//     for URLs that were never pulled. Narrowing to the exact leaves is not
+	//     available to us: v2's layout is `resolve(cache,"skills",Bun.hash(url))`
+	//     (offset 103375250) and `Bun.hash` is a Bun-only API, unusable here
+	//     under AGENTS.md invariant 2 (the bundle must stay Node-ESM-loadable);
+	//     v1 (offset 102988349) uses a different destination scheme again.
+	//
+	//     CONSEQUENCE, stated plainly: `external_directory` has no read/write
+	//     split, so this is a WRITE grant over that subtree. `Discovery.download`
+	//     short-circuits on an existing destination
+	//     (`if (yield* j.exists(T)) return !0`, offset 102988349; v2 additionally
+	//     skips on a matching `.opencode-version`, offset 103375250) and
+	//     destinations are deterministic. A lane can therefore pre-plant content
+	//     at a path a LATER, DIFFERENT session's host will decline to overwrite
+	//     and will then load as skill instructions — a cross-session write→load
+	//     path. That is the same blast radius cited for excluding the plugin
+	//     install dirs. It is accepted here only because the alternative is
+	//     breaking URL skills in lanes outright, and only when the operator has
+	//     opted into `skills.urls` at all.
+	//
+	//     SCOPE: `<cache>/opencode/skills` ONLY, never `<cache>/opencode`. The
+	//     host defines `bin: join(cache,"bin")` (offset 107378747) and creates
+	//     it at startup — a directory the host EXECUTES from. Granting the parent
+	//     would put executable code inside the write grant. Same reasoning that
+	//     dropped getPluginCachePaths() and narrowed os.tmpdir() above.
+	const skillUrls = Array.isArray(configuredSkillUrls)
+		? configuredSkillUrls
+		: [];
+	if (skillUrls.some((u) => typeof u === 'string' && u.trim() !== '')) {
+		push(
+			out,
+			seen,
+			getHostSkillCacheDir(),
+			'URL-sourced skill cache (only because skills.urls is configured)',
+		);
+	}
+	// Back to (d): the `skills.paths` loop. (The (e) cache grant above is a
+	// single push and needs no per-entry handling, so it was placed before this
+	// loop rather than after it.)
+	//
 	// Defence in depth for the one argument that carries user data.
-	// `readConfiguredSkillPaths` already normalises this, but allowlist
+	// `readConfiguredSkillList` already normalises this, but allowlist
 	// construction runs on the plugin-init path, so a malformed `skills` config
 	// must not be able to throw.
 	//
@@ -744,20 +806,24 @@ export interface LanePermissionApplication {
 }
 
 /**
- * Reads `skills.paths` out of the live config object the hook was handed.
+ * Reads `skills.paths` or `skills.urls` out of the live config object the hook
+ * was handed, selected by `key`.
  *
  * Pure object access — no filesystem, no network — so it is safe on the
  * plugin-init path. Anything that is not an array of strings yields an empty
- * list rather than throwing.
+ * list rather than throwing, and blank or whitespace-only entries are dropped.
  */
-function readConfiguredSkillPaths(
+function readConfiguredSkillList(
 	opencodeConfig: Record<string, unknown>,
+	key: 'paths' | 'urls',
 ): string[] {
 	const skills = opencodeConfig.skills;
 	if (!skills || typeof skills !== 'object' || Array.isArray(skills)) return [];
-	const paths = (skills as Record<string, unknown>).paths;
-	if (!Array.isArray(paths)) return [];
-	return paths.filter((p): p is string => typeof p === 'string');
+	const value = (skills as Record<string, unknown>)[key];
+	if (!Array.isArray(value)) return [];
+	return value.filter(
+		(v): v is string => typeof v === 'string' && v.trim() !== '',
+	);
 }
 
 /**
@@ -907,7 +973,11 @@ export function applyLanePermissions(
 
 	const allowlist =
 		mode === 'scoped_allow'
-			? buildLaneAllowlist(lane, readConfiguredSkillPaths(opencodeConfig))
+			? buildLaneAllowlist(
+					lane,
+					readConfiguredSkillList(opencodeConfig, 'paths'),
+					readConfiguredSkillList(opencodeConfig, 'urls'),
+				)
 			: [];
 	const build = buildLaneExternalDirectoryRules(
 		mode,

--- a/src/config/lane-permissions.ts
+++ b/src/config/lane-permissions.ts
@@ -1,0 +1,947 @@
+/**
+ * Scoped `external_directory` permission rules for swarm worktree-lane
+ * instances.
+ *
+ * ## The problem this solves
+ *
+ * A lane session is created against a new directory, so OpenCode builds it a
+ * fresh directory-keyed permission universe with an empty `approved` list. The
+ * host's default agent ruleset ends in `external_directory: { "*": "ask" }`, and
+ * a lane instance has no TUI attached to answer an ask — `Permission.ask` parks
+ * on a deferred with no timeout and the lane hangs forever.
+ *
+ * ## The mechanism
+ *
+ * The plugin `config` hook runs once per OpenCode instance (`Plugin.state` is
+ * built through the same directory-keyed `InstanceState` cache as
+ * `Permission.state`), so in a lane instance it runs with `ctx.directory` set to
+ * the lane path. Rules merged into the top-level `permission` block there are
+ * folded by the host into **every** agent's ruleset:
+ *
+ * ```js
+ * // opencode host, Agent.state
+ * l = a.fromConfig(p.permission ?? {})            // top-level config permission
+ * r = { build: { permission: a.merge(c, ..., l) }, plan: {...}, general: {...},
+ *       explore: {...}, compaction: {...}, title: {...}, summary: {...} }
+ * for (const [n, s] of Object.entries(p.agent ?? {})) {
+ *   let e = r[n];
+ *   if (!e) e = r[n] = { ..., permission: a.merge(c, l), ... };   // swarm agents
+ *   e.permission = a.merge(e.permission, a.fromConfig(s.permission ?? {}));
+ * }
+ * ```
+ *
+ * Top-level is therefore strictly broader than per-agent injection: it reaches
+ * the host-native agents (`build`, `plan`, `general`, `explore`, ...) that a
+ * lane can also run, and it lands *before* any per-agent block so explicit
+ * per-agent user config still wins. Injecting the same rules per-agent as well
+ * would duplicate every rule in every ruleset and would make our injected rules
+ * outrank the user's own top-level entries — the wrong precedence.
+ *
+ * ## DISCLOSED ASSUMPTION: hook-before-agents ordering
+ *
+ * This design requires the `config` hook to run before `Agent.state` reads the
+ * config. What is PROVEN: both sides touch the *same* object — `Plugin.state`
+ * does `U = yield* Config.get()` and mutates `U` in place, `Agent.state` does
+ * `p = yield* Config.get()`, and `Config.state` is InstanceState-cached, so
+ * `get()` returns one shared instance. There is no copy; only ordering is in
+ * question.
+ *
+ * What is NOT proven: any static ordering guarantee. Two bounded searches of
+ * the host binary came back negative — the Agent layer's deps
+ * (`deps:[J.node,O.node,P.node,_.node,$.node,Ve]`, offset 100817167) do not
+ * include the Plugin node (the three symbols the Agent chunk imports from the
+ * Plugin chunk are `$G`, `b8`, `r1`, none of which is the Plugin service), and
+ * `Plugin.init` (offset 102128681) has no caller anywhere in the bundle. The
+ * hook therefore fires lazily, when `Plugin.state` is first populated by a
+ * `Plugin.trigger` / `Plugin.list`.
+ *
+ * The evidence that it holds is empirical and strong: opencode-swarm's agents
+ * are registered ONLY by this config hook, and they demonstrably appear in the
+ * TUI, which is impossible unless the hook ran before `Agent.state` was built.
+ * Treat it as a verified-in-practice property of this host build rather than a
+ * contract. If a future OpenCode release reorders layer construction, the
+ * symptom is loud and immediate — no swarm agents at all — not a silent
+ * permission regression.
+ *
+ * ## Rule ordering is load-bearing
+ *
+ * The host evaluates with `findLast` over the flattened rule list:
+ *
+ * ```js
+ * function c(j, J, ...K) {
+ *   return K.flat().findLast((z) => g.match(j, z.permission) && g.match(J, z.pattern))
+ *          ?? { action: "ask", permission: j, pattern: "*" };
+ * }
+ * ```
+ *
+ * and `fromConfig` preserves `Object.entries` order. So **later wins**, and the
+ * catch-all `"*": "deny"` must be emitted FIRST, before the specific allows.
+ * Emitting it last would deny everything. `tests/unit/config/lane-permissions.test.ts`
+ * pins this against a faithful re-implementation of the host's own
+ * `fromConfig`/`merge`/`evaluate`, so the ordering contract is verified rather
+ * than assumed.
+ *
+ * Two further host behaviours matter and are deliberately relied upon:
+ *
+ *  - `Wildcard.match` compiles the rule pattern with `*` -> `.*` under the `s`
+ *    (dotAll) flag, so `<dir>/*` covers the entire subtree, and it normalises
+ *    `\` to `/` on both sides before matching, so native Windows paths are fine.
+ *  - After merging config, the host appends
+ *    `external_directory: { <Global.Path.data>/tool-output/*: "allow" }` to every
+ *    agent unless a rule already matches that exact pattern with `action: "deny"`.
+ *    Our catch-all uses pattern `"*"`, which does not satisfy that exact-string
+ *    check, so the append still happens and still lands last. Tool output stays
+ *    readable. The emitted ruleset is intentionally not the final ruleset.
+ *
+ * @module config/lane-permissions
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { SKILL_SEARCH_ROOTS } from '../hooks/skill-propagation-gate';
+import { validateSwarmPath } from '../hooks/utils';
+import { addDeferredWarning } from '../services/warning-buffer';
+import {
+	getHostConfigDir,
+	getHostDataDir,
+	getPluginConfigDir,
+} from './cache-paths';
+import { hostNormalizePathPattern } from './host-path';
+import type { LaneContext } from './lane-context';
+import { resolveLaneContext } from './lane-context';
+
+/**
+ * Lane permission policy. Mirrors `worktree.lane_permissions` in
+ * `src/config/schema.ts`.
+ */
+export type LanePermissionMode = 'scoped_allow' | 'deny' | 'off';
+
+/** Permission actions OpenCode understands for a rule. */
+type PermissionAction = 'allow' | 'ask' | 'deny';
+
+/**
+ * An `external_directory` rule map whose ONLY insertion semantics are
+ * "last write wins, and lands last".
+ *
+ * ## Why this class exists
+ *
+ * The host evaluates with `findLast` over `Object.entries` order, so a rule's
+ * POSITION is its precedence. Plain assignment (`rules[k] = v`) does not move an
+ * existing key — it updates the value in place and the key keeps its ORIGINAL
+ * slot. Writing the catch-all `'*'` first and then re-assigning it from user
+ * config therefore leaves the user's rule at index 0, behind the entire plugin
+ * allowlist, so the allowlist beats the operator's explicit deny-all. Because
+ * `external_directory` has no read/write split, that silently re-grants WRITE
+ * access against a deliberate lockdown.
+ *
+ * This is the third appearance of one defect class (precedence via JS object
+ * key insertion order), so the fix is structural rather than another
+ * `delete`-then-`set` at a call site: every write to THIS map goes through
+ * {@link set}, which deletes an existing key before re-inserting it so the last
+ * writer is always last in iteration order. The map's internals are private and
+ * {@link toObject} rebuilds a fresh object from the ordered entries, so a caller
+ * cannot bypass the ordering by assigning to it.
+ *
+ * Scope note: this governs the `external_directory` map assembled here. It does
+ * NOT govern the separate per-agent sweep in `downgradeAgentAskRules`, which
+ * rewrites values in a config object the host owns. That sweep intentionally
+ * mutates in place — it only changes `'ask'` to `'deny'` on keys the user
+ * already wrote, and moving those keys would silently re-order the user's own
+ * precedence.
+ */
+class LastWinsRuleMap {
+	private readonly entries = new Map<string, PermissionAction>();
+
+	/** Inserts or re-inserts `pattern` so it becomes the LAST rule. */
+	set(pattern: string, action: PermissionAction): void {
+		// Map preserves insertion order and `delete` frees the slot, so a
+		// re-inserted key moves to the end — exactly the precedence we need.
+		this.entries.delete(pattern);
+		this.entries.set(pattern, action);
+	}
+
+	/** Materialises the rules as a plain object in evaluation order. */
+	toObject(): Record<string, PermissionAction> {
+		return Object.fromEntries(this.entries);
+	}
+}
+
+/**
+ * Directory names the host's skill glob accepts, mirroring
+ * `SA = "{skill,skills}/**\/SKILL.md"` (binary offset 102990880). Both
+ * spellings are supported for `Config.directories()` roots, so the allowlist
+ * grants the pair from this one definition rather than hardcoding either.
+ */
+const SKILL_DIR_NAMES = ['skill', 'skills'] as const;
+
+/**
+ * Home/project skill marker directories the host scans with the PLURAL-only
+ * glob `GA = "skills/**\/SKILL.md"` — verbatim `bA = ".claude"`,
+ * `xA = ".agents"` (same offset).
+ */
+const HOST_HOME_SKILL_MARKERS = ['.claude', '.agents'] as const;
+
+/** Result of assembling a lane's `external_directory` rule map. */
+interface LaneRuleBuild {
+	/** The rule map, in emission (== evaluation) order. */
+	rules: Record<string, PermissionAction>;
+	/**
+	 * User-configured patterns whose `"ask"` was coerced to `"deny"` because a
+	 * lane has no TUI that could answer an ask. Empty in the common case.
+	 */
+	coercedAskPatterns: string[];
+}
+
+/** An allowlisted directory plus the justification for granting it. */
+interface LaneAllowlistEntry {
+	/** Absolute directory path. */
+	dir: string;
+	/**
+	 * The emitted `external_directory` rule pattern for {@link dir}.
+	 *
+	 * Computed ONCE here and reused by both consumers — the rule map and the
+	 * `.swarm/events.jsonl` record. Deriving it twice meant a second round of
+	 * `realpathSync.native` per entry on the config-hook path and, more
+	 * importantly, left room for the two to disagree: if they ever did, the
+	 * event log would misreport the rule that was actually emitted, which is
+	 * precisely the observability this subsystem exists to provide.
+	 */
+	pattern: string;
+	/** Why this directory is justified — recorded in `.swarm/events.jsonl`. */
+	reason: string;
+}
+
+/**
+ * Converts an absolute directory into the `external_directory` rule pattern
+ * that covers it and everything beneath it.
+ *
+ * The literal part of the directory is escaped for the host's matcher. The host
+ * compiles a rule pattern as:
+ *
+ * ```js
+ * o.replace(/[.+^${}()|[\]\\]/g,"\\$&").replace(/\*​/g,".*").replace(/\?/g,".")
+ * // then: new RegExp("^"+compiled+"$","si")
+ * ```
+ *
+ * Note what is NOT escaped: `*` and `?`. A directory legitimately named `a*`
+ * (legal on POSIX) would compile to `a.*` and silently grant every sibling
+ * starting with `a`; `?` becomes a single-character wildcard the same way. The
+ * matcher offers no escape syntax for either, so such a directory cannot be
+ * expressed exactly. {@link isExpressibleDirectory} therefore drops it from the
+ * allowlist rather than emitting an over-broad grant: dropping fails safe (the
+ * path is denied, and its absence is visible in the event log), emitting would
+ * fail open.
+ *
+ * The matcher also uses the `i` flag, so patterns are case-insensitive even on
+ * case-sensitive filesystems. `/home/u/Work/*` will therefore also match
+ * `/home/u/work/...`. That widening is inherent to the host and cannot be
+ * avoided from a rule pattern; it is recorded here so it is a known, reviewed
+ * property rather than a surprise.
+ */
+function laneDirectoryPattern(dir: string): string {
+	// MUST mirror the host. The asked pattern is produced by
+	// `Filesystem.normalizePathPattern`, which realpaths the directory part; a
+	// rule from config gets no such treatment (`fromConfig` only expands `~`).
+	// Emitting the un-canonicalised form means a lane reached through a junction
+	// or symlink is denied access to its own grant, because the two strings
+	// never converge.
+	return hostNormalizePathPattern(path.join(dir, '*'));
+}
+
+/**
+ * True when `dir` can be expressed as an exact `external_directory` pattern.
+ *
+ * The host's pattern compiler does not escape `*` or `?`, so a directory whose
+ * own name contains either character cannot be pinned down — any pattern we
+ * emit for it would match strictly more than the directory itself. Such a
+ * directory is excluded from the allowlist (fail safe) rather than granted
+ * (fail open).
+ */
+function isExpressibleDirectory(dir: string): boolean {
+	return !dir.includes('*') && !dir.includes('?');
+}
+
+function push(
+	out: LaneAllowlistEntry[],
+	seen: Set<string>,
+	dir: string | undefined,
+	reason: string,
+): void {
+	if (!dir) return;
+	let resolved: string;
+	try {
+		resolved = path.resolve(dir);
+	} catch {
+		return;
+	}
+	// A directory containing `*` or `?` cannot be expressed exactly — see
+	// isExpressibleDirectory. Drop it (denied) rather than emit a pattern that
+	// grants more than intended.
+	if (!isExpressibleDirectory(resolved)) return;
+	// Deduplicate case-insensitively on Windows so the same directory reached by
+	// two spellings does not produce two rules.
+	const key = process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+	if (seen.has(key)) return;
+	seen.add(key);
+	out.push({ dir: resolved, pattern: laneDirectoryPattern(resolved), reason });
+}
+
+/**
+ * Builds the justified `external_directory` allowlist for a lane.
+ *
+ * Every entry is a directory the lane provably needs in order to do the work it
+ * was created for. Nothing is added "just in case" — an over-broad allowlist
+ * here is the security cost of this fix, so each entry carries its reason and
+ * is asserted in tests.
+ *
+ * @param lane - Resolved lane context.
+ * @returns Deduplicated absolute directories with justifications.
+ */
+function buildLaneAllowlist(
+	lane: LaneContext,
+	configuredSkillPaths: readonly string[] = [],
+): LaneAllowlistEntry[] {
+	const out: LaneAllowlistEntry[] = [];
+	const seen = new Set<string>();
+
+	// The project this lane is literally a git worktree of. Without this the
+	// lane cannot read the sources it was branched from.
+	push(
+		out,
+		seen,
+		lane.parentProjectPath,
+		'parent project the lane is a git worktree of',
+	);
+
+	// The lane itself. The host already treats the instance directory as
+	// internal, but stating it makes the ruleset self-describing and keeps the
+	// lane reachable if the host's own default ever narrows.
+	push(out, seen, lane.lanePath, 'the lane worktree itself');
+
+	// The OpenCode config tree the host is actually reading (global agents,
+	// commands, skills). `getHostConfigDir` honours OPENCODE_CONFIG_DIR, which
+	// `getPluginConfigDir` deliberately does not.
+	//
+	// NOTE the plugin cache/install locations (`getPluginCachePaths()`) are
+	// intentionally NOT granted. `external_directory` has no read/write split,
+	// so every entry here is also a WRITE grant, and a lane has no legitimate
+	// reason to write to the plugin's own installed code — which the host then
+	// executes in-process on the next load, outside lane teardown.
+	// DELIBERATE WIDENING (not a restoration). The host's per-agent base allow is
+	//   q = [A.GLOB, join(Global.Path.tmp,'*'), ...Skill.dirs(), ...config-references]
+	// (Agent.state, offset 100811506; the `G` there resolves to the SKILL service —
+	// the Agent chunk imports `zr as _` from chunk-mdqr1haw.js, whose `zr` is the
+	// Skill namespace exposing `dirs`). OpenCode's CONFIG directories are NOT in
+	// that list, so granting them is a choice we are making, justified by the lane
+	// needing to read global agent/command/skill definitions.
+	//
+	// Both config dirs are granted because the host resolves them from two
+	// different places: `ConfigPaths.directories` (offset 103303216) reads
+	// `I.Path.config` — the Global namespace's static `Path`, bound to the RAW
+	// object whose `config` is join(XDG_CONFIG_HOME,'opencode') WITHOUT the
+	// override (offset 107378114) — and separately appends OPENCODE_CONFIG_DIR
+	// when set. The override is applied only by the `y()` service factory
+	// (offset 107379448). Granting one and not the other would leave a directory
+	// OpenCode actually reads inaccessible.
+	push(
+		out,
+		seen,
+		getPluginConfigDir(),
+		'OpenCode XDG config dir (host Global.Path.config)',
+	);
+	push(
+		out,
+		seen,
+		getHostConfigDir(),
+		'OpenCode config dir override (OPENCODE_CONFIG_DIR), when set',
+	);
+
+	// Temp scratch. Deliberately NOT all of `os.tmpdir()`: that is a shared,
+	// world-writable-ish tree on POSIX and granting it wholesale would let a
+	// lane write into any other process's temp state. Two narrow subtrees only:
+	//   - `<tmpdir>/opencode`, the host's own temp area;
+	//   - `<tmpdir>/swwt`, where `shortenWorktreePath()` relocates a lane when
+	//     the Windows path budget is exceeded. A shortened lane's own directory
+	//     is already covered by the lane entry above, but sibling lanes of the
+	//     same run live under this root and lane merge-back reads across them.
+	// `path.join(os.tmpdir(), 'opencode')` is exactly the host's own
+	// `Global.Path.tmp` (binary offset 107378900: `jn=H.join(r.tmpdir(),W)` with
+	// `W = "opencode"`), which the host base-allows for every agent. Re-granting
+	// it keeps a lane no more restricted than an ordinary session.
+	const tmpRoot = os.tmpdir();
+	push(
+		out,
+		seen,
+		path.join(tmpRoot, 'opencode'),
+		"OpenCode's own temp dir (host Global.Path.tmp)",
+	);
+	// Windows only. `shortenWorktreePath` fires solely on the Windows path-budget
+	// check, so on POSIX this directory is never created and granting it would be
+	// a pointless write grant into a sticky-bit, world-writable tree.
+	if (process.platform === 'win32') {
+		push(
+			out,
+			seen,
+			path.join(tmpRoot, 'swwt'),
+			'shortened-worktree lane root (Windows path-budget fallback)',
+		);
+	}
+
+	// RESTORATION: the host natively grants its `plan` agent
+	// `external_directory: { join(Path.data,'plans','*'): 'allow' }`
+	// (Agent.state, offset ~100812132). That rule is merged BEFORE the top-level
+	// block, so our catch-all would outrank it under `findLast` and a lane
+	// running `plan` would be denied its own plan storage — a clean DeniedError
+	// rather than a hang, but a real documented capability lost.
+	push(
+		out,
+		seen,
+		path.join(getHostDataDir(), 'plans'),
+		"OpenCode plan storage (host `plan` agent's native allow)",
+	);
+
+	// Configured skill roots, resolved against both trees the lane can legally
+	// read from, plus the user-level roots OpenCode itself scans.
+	//
+	// Unlike the config dirs above, these ARE a restoration: the host's
+	// per-agent base allow includes ...Skill.dirs() (Agent.state, offset
+	// 100811506), i.e. every directory skill discovery found. Without
+	// re-granting them the catch-all deny would make a lane strictly more
+	// restricted than an ordinary session. The field log
+	// for this defect shows the hang on
+	// `C:\Users\Brett\.claude\skills\engineering-conventions\*` — a user-level
+	// skill root — so these are not optional.
+	let home: string | undefined;
+	try {
+		home = os.homedir();
+	} catch {
+		home = undefined;
+	}
+
+	// NOTE: the whole `~/.opencode` tree is deliberately NOT granted.
+	//
+	// It was originally added on the belief that the host base-allows
+	// `ConfigPaths.directories()`; that turned out to be false (the per-agent
+	// base allow is `Skill.dirs()`, not the config dirs). Two facts then make the
+	// whole-tree grant both unnecessary and unsafe:
+	//
+	//  - Unnecessary: the parts a lane's AGENT actually reads are the skill
+	//    roots, and BOTH `~/.opencode/skill` and `~/.opencode/skills` are granted
+	//    individually below (the host's glob accepts either spelling — granting
+	//    only the plural one silently denied the singular layout, which is what
+	//    the whole-tree grant used to cover). Global agent/command/plugin
+	//    definitions under `~/.opencode` are loaded by the HOST process: only
+	//    three sites in the binary reference `permission:"external_directory"`
+	//    and both enforcers are tool-side, so config loading never consults it.
+	//  - Unsafe: `external_directory` has no read/write split, and OpenCode's
+	//    GitLab OAuth helper (offsets 101269799, 102089082) stores credentials at
+	//    `XDG_DATA_HOME ? join(XDG_DATA_HOME,'opencode','auth.json')
+	//                   : join(homedir(),'.opencode','auth.json')`.
+	//    With XDG_DATA_HOME unset — the default on Windows and macOS — that file
+	//    sits directly inside `~/.opencode`, so granting the tree would put a
+	//    credential file inside a lane's write grant.
+	//
+	// A user who genuinely needs more of `~/.opencode` in a lane adds an explicit
+	// `permission.external_directory` allow, which always wins.
+	// Mirror the HOST's skill discovery (offset 102990880) rather than encoding
+	// half of it. Verbatim constants:
+	//   bA = ".claude"   xA = ".agents"
+	//   GA = "skills/**/SKILL.md"           <- PLURAL only
+	//   SA = "{skill,skills}/**/SKILL.md"   <- singular OR plural
+	// and the scan is:
+	//   .claude/.agents at $HOME  -> GA
+	//   .claude/.agents walked from directory to worktree -> GA
+	//   every Config.directories() entry -> SA
+	//
+	// Granting only `skills` for a Config.directories() root silently denies the
+	// supported singular `skill/` layout, which is what the removed whole-tree
+	// `~/.opencode` grant used to cover. The pair is derived from one constant so
+	// the two spellings cannot drift apart.
+	const projectRoots = [
+		{ base: lane.parentProjectPath, label: 'parent project' },
+		{ base: lane.lanePath, label: 'lane' },
+	];
+
+	// (a) `.claude` / `.agents` roots — host scans PLURAL `skills` only.
+	for (const marker of HOST_HOME_SKILL_MARKERS) {
+		for (const { base, label } of projectRoots) {
+			push(
+				out,
+				seen,
+				path.resolve(base, marker, 'skills'),
+				`skill root (${label}): ${marker}/skills`,
+			);
+		}
+		if (home) {
+			push(
+				out,
+				seen,
+				path.resolve(home, marker, 'skills'),
+				`skill root (user level): ~/${marker}/skills`,
+			);
+		}
+	}
+
+	// (b) Config.directories()-style roots — host scans BOTH `skill` and
+	//     `skills`.
+	const configSkillRoots: Array<{ base: string; label: string }> = [
+		{ base: getPluginConfigDir(), label: 'XDG config dir' },
+		{ base: getHostConfigDir(), label: 'config dir override' },
+		...projectRoots.map(({ base, label }) => ({
+			base: path.resolve(base, '.opencode'),
+			label: `${label} .opencode`,
+		})),
+		...(home
+			? [{ base: path.join(home, '.opencode'), label: 'user-level .opencode' }]
+			: []),
+	];
+	for (const { base, label } of configSkillRoots) {
+		for (const dirName of SKILL_DIR_NAMES) {
+			push(
+				out,
+				seen,
+				path.resolve(base, dirName),
+				`skill root (${label}): ${dirName}/`,
+			);
+		}
+	}
+
+	// (c) The plugin's OWN gate list (`SKILL_SEARCH_ROOTS`). Union'd in so a root
+	//     added there is granted even if the host layout above does not cover it.
+	for (const relative of SKILL_SEARCH_ROOTS) {
+		for (const { base, label } of projectRoots) {
+			push(
+				out,
+				seen,
+				path.resolve(base, relative),
+				`skill root (${label}): ${relative}`,
+			);
+		}
+		if (home) {
+			push(
+				out,
+				seen,
+				path.resolve(home, relative),
+				`skill root (user level): ~/${relative}`,
+			);
+		}
+	}
+
+	// (d) Config `skills.paths`. Resolved exactly as the host does (offset
+	//     102994011): `~/` expands to $HOME, a relative path anchors to the
+	//     instance directory. This is a pure read of the config object the hook
+	//     already holds — no I/O, so invariant 1 is unaffected. The host also
+	//     `isDir`-checks each one; we deliberately do not, because granting a
+	//     path that does not exist yet is harmless and a stat per entry is not.
+	//
+	//     `skills.urls` are NOT granted: the host pulls them over the network
+	//     into a cache directory this hook cannot resolve without doing the pull
+	//     itself. Disclosed in docs/configuration.md.
+	// Defence in depth for the one argument that carries user data.
+	// `readConfiguredSkillPaths` already normalises this, but allowlist
+	// construction runs on the plugin-init path, so a malformed `skills` config
+	// must not be able to throw.
+	//
+	// Scope note, so the claim matches the code: `lane` itself is NOT guarded — a
+	// null lane or a non-string `lanePath` would throw. That is unreachable by
+	// construction rather than by validation: `applyLanePermissions` returns
+	// early on `!lane`, `resolveLaneContext` only ever yields `path.resolve`
+	// strings, and the `src/index.ts` call site wraps the whole thing in
+	// try/catch. Adding a guard here would be unreachable defensive code.
+	const skillPaths = Array.isArray(configuredSkillPaths)
+		? configuredSkillPaths
+		: [];
+	for (const configured of skillPaths) {
+		if (typeof configured !== 'string' || configured.trim() === '') continue;
+		const expanded =
+			configured.startsWith('~/') && home
+				? path.join(home, configured.slice(2))
+				: configured;
+		push(
+			out,
+			seen,
+			path.isAbsolute(expanded)
+				? expanded
+				: path.resolve(lane.lanePath, expanded),
+			`configured skills.path: ${configured}`,
+		);
+	}
+
+	return out;
+}
+
+/**
+ * Normalises the `external_directory` value already present in a config
+ * `permission` block into rule-object form.
+ *
+ * OpenCode accepts either a shorthand string (`"allow"`) or a pattern map. The
+ * shorthand is equivalent to `{ "*": <value> }`.
+ */
+function normalizeExisting(
+	existing: unknown,
+): Record<string, PermissionAction> | undefined {
+	if (typeof existing === 'string') {
+		return { '*': existing as PermissionAction };
+	}
+	if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+		return { ...(existing as Record<string, PermissionAction>) };
+	}
+	return undefined;
+}
+
+/**
+ * Builds the `external_directory` rule map to write into the top-level
+ * `permission` block of a lane instance's config.
+ *
+ * Emission order (which IS the evaluation order, later-wins):
+ *
+ *  1. `"*": "deny"` — our catch-all, so nothing can be left pending in a lane
+ *     that has no TUI to answer it. This is the only mechanism that delivers
+ *     the approved policy's "answered, not hung" guarantee now that the host's
+ *     `permission.ask` plugin hook is confirmed dead (never triggered by
+ *     opencode 1.18.10).
+ *  2. Our justified allowlist — beats the catch-all because it comes later.
+ *  3. Whatever the user already configured — beats everything, because explicit
+ *     user configuration must always outrank a plugin default. A user entry
+ *     keyed `"*"` replaces our catch-all's value in place (same key), so
+ *     `external_directory: "allow"` in `opencode.json` still means allow-all.
+ *
+ * ## Why `"ask"` is coerced to `"deny"` INSIDE A LANE
+ *
+ * A user's `allow` and `deny` are honoured verbatim. `ask` is not, and that is
+ * deliberate: a lane instance has no TUI attached, so `ask` cannot be answered
+ * by anyone. It is not a third policy choice there — it is a guaranteed
+ * indefinite hang, which is the exact defect this module exists to remove.
+ * Honouring it literally would let a top-level `external_directory: "ask"` (or
+ * any `"ask"` pattern) silently reinstate the bug while this code reported
+ * success. Coercion resolves to the fail-safe direction (`deny`, never
+ * `allow`), the affected patterns are named in the advisory, and they are
+ * recorded under `coercedAskPatterns` in the `.swarm/events.jsonl` entry so the
+ * decision is auditable rather than silent. Users who genuinely want the
+ * prompting behaviour back have `worktree.lane_permissions: "off"`.
+ *
+ * @param mode     - Configured lane permission policy.
+ * @param lane     - Resolved lane context.
+ * @param existing - Current `external_directory` value from the config being
+ *                   mutated, if any.
+ * @returns The rule map plus any patterns whose `ask` was coerced, or `null`
+ *          when the policy is `off` (the caller must then touch nothing).
+ */
+function buildLaneExternalDirectoryRules(
+	mode: LanePermissionMode,
+	lane: LaneContext,
+	existing?: unknown,
+	// Precomputed by the caller so the allowlist is built once per lane rather
+	// than twice on the plugin-init path.
+	precomputedAllowlist?: readonly LaneAllowlistEntry[],
+): LaneRuleBuild | null {
+	if (mode === 'off') return null;
+
+	const rules = new LastWinsRuleMap();
+	rules.set('*', 'deny');
+
+	if (mode === 'scoped_allow') {
+		for (const entry of precomputedAllowlist ?? buildLaneAllowlist(lane)) {
+			rules.set(entry.pattern, 'allow');
+		}
+	}
+
+	const coercedAskPatterns: string[] = [];
+	const user = normalizeExisting(existing);
+	if (user) {
+		for (const [pattern, action] of Object.entries(user)) {
+			if (action === 'ask') {
+				// Unanswerable in a lane — see the "Why `ask` is coerced" note above.
+				coercedAskPatterns.push(pattern);
+				rules.set(pattern, 'deny');
+				continue;
+			}
+			rules.set(pattern, action);
+		}
+	}
+
+	return { rules: rules.toObject(), coercedAskPatterns };
+}
+
+/**
+ * Renders the operator-facing remedy text for a lane whose permissions are
+ * being scoped.
+ *
+ * The permission system itself carries an action, not a message — a `deny` rule
+ * cannot explain itself. So the explanation is delivered out-of-band (a deferred
+ * warning plus a `.swarm/events.jsonl` record) and names the exact
+ * `opencode.json` edit that widens the allowlist.
+ */
+function renderLanePermissionAdvisory(
+	mode: Exclude<LanePermissionMode, 'off'>,
+	lane: LaneContext,
+	allowlist: readonly LaneAllowlistEntry[],
+	coercedAskPatterns: readonly string[] = [],
+): string {
+	const scope =
+		mode === 'deny'
+			? 'ALL external directory access is denied in this lane'
+			: `external directory access is limited to ${allowlist.length} justified path(s)`;
+	const parts = [
+		`[swarm] Worktree-lane permissions active for ${lane.lanePath} (worktree of ${lane.parentProjectPath}).`,
+		`Policy worktree.lane_permissions="${mode}": ${scope}; anything else is denied rather than left pending.`,
+		'A lane instance has no TUI attached, so an "ask" there can never be answered and would hang the lane forever.',
+	];
+	if (coercedAskPatterns.length > 0) {
+		parts.push(
+			`Your configured external_directory "ask" rule(s) [${coercedAskPatterns.join(', ')}] were treated as "deny" here for that reason — change them to "allow" if the lane needs those paths.`,
+		);
+	}
+	parts.push(
+		'To widen the allowlist, add the directory to opencode.json:',
+		'  { "permission": { "external_directory": { "<absolute-dir>/*": "allow" } } }',
+		'To restore the previous (hanging) behaviour, set worktree.lane_permissions to "off".',
+	);
+	return parts.join(' ');
+}
+
+/**
+ * Tier-0 test seam (see the writing-tests skill): these are pure functions with
+ * no external dependencies, so they are tested directly rather than mocked.
+ * They are intentionally NOT part of the module's public API — only
+ * {@link applyLanePermissions} is called from production.
+ */
+export const _test_exports = {
+	buildLaneAllowlist,
+	buildLaneExternalDirectoryRules,
+	laneDirectoryPattern,
+	renderLanePermissionAdvisory,
+};
+
+/**
+ * Test-only dependency-injection seam (AGENTS.md invariant 7). Tests replace
+ * these to assert the event record and advisory without touching the real
+ * filesystem or the process-wide warning buffer. Restore in `afterEach`.
+ */
+export const _internals = {
+	resolveLaneContext,
+	addDeferredWarning,
+	appendFileSync: fs.appendFileSync as (
+		p: string,
+		data: string,
+		enc: BufferEncoding,
+	) => void,
+	mkdirSync: fs.mkdirSync as (
+		p: string,
+		opts: { recursive: boolean },
+	) => string | undefined,
+};
+
+/** Outcome of {@link applyLanePermissions}, returned for tests and logging. */
+export interface LanePermissionApplication {
+	/** `true` when the directory was recognised as a swarm worktree lane. */
+	lane: boolean;
+	/** Effective policy. `undefined` when `lane` is `false`. */
+	mode?: LanePermissionMode;
+	/** Rules written into `permission.external_directory`, when any. */
+	rules?: Record<string, PermissionAction>;
+}
+
+/**
+ * Reads `skills.paths` out of the live config object the hook was handed.
+ *
+ * Pure object access — no filesystem, no network — so it is safe on the
+ * plugin-init path. Anything that is not an array of strings yields an empty
+ * list rather than throwing.
+ */
+function readConfiguredSkillPaths(
+	opencodeConfig: Record<string, unknown>,
+): string[] {
+	const skills = opencodeConfig.skills;
+	if (!skills || typeof skills !== 'object' || Array.isArray(skills)) return [];
+	const paths = (skills as Record<string, unknown>).paths;
+	if (!Array.isArray(paths)) return [];
+	return paths.filter((p): p is string => typeof p === 'string');
+}
+
+/**
+ * Rewrites every `external_directory: "ask"` in a per-agent `permission` block
+ * to `"deny"`, in place, and returns the affected `<agent>.<pattern>` labels.
+ *
+ * Necessary because the host merges per-agent permission LAST:
+ * `e.permission = a.merge(e.permission, a.fromConfig(s.permission ?? {}))`.
+ * Coercing only the top-level block would therefore be trivially bypassed by
+ * any agent that declares its own `external_directory` ask — the rule that
+ * actually wins at evaluation time.
+ *
+ * Handles both accepted config shapes: the string shorthand
+ * (`external_directory: "ask"`, equivalent to `{ "*": "ask" }`) and the pattern
+ * map.
+ */
+function downgradeAgentAskRules(
+	opencodeConfig: Record<string, unknown>,
+): string[] {
+	const coerced: string[] = [];
+	const agents = opencodeConfig.agent;
+	if (!agents || typeof agents !== 'object' || Array.isArray(agents)) {
+		return coerced;
+	}
+	for (const [agentName, rawAgent] of Object.entries(
+		agents as Record<string, unknown>,
+	)) {
+		if (!rawAgent || typeof rawAgent !== 'object' || Array.isArray(rawAgent)) {
+			continue;
+		}
+		const agent = rawAgent as Record<string, unknown>;
+		const rawPermission = agent.permission;
+		if (
+			!rawPermission ||
+			typeof rawPermission !== 'object' ||
+			Array.isArray(rawPermission)
+		) {
+			continue;
+		}
+		const agentPermission = rawPermission as Record<string, unknown>;
+		const external = agentPermission.external_directory;
+		if (external === 'ask') {
+			agentPermission.external_directory = 'deny';
+			coerced.push(`${agentName}.*`);
+			continue;
+		}
+		if (!external || typeof external !== 'object' || Array.isArray(external)) {
+			continue;
+		}
+		const map = external as Record<string, unknown>;
+		for (const [pattern, action] of Object.entries(map)) {
+			if (action !== 'ask') continue;
+			map[pattern] = 'deny';
+			coerced.push(`${agentName}.${pattern}`);
+		}
+	}
+	return coerced;
+}
+
+/**
+ * Appends one structured decision record to `<directory>/.swarm/events.jsonl`.
+ *
+ * Best-effort by design: observability must never be able to break plugin
+ * initialisation. Note the lane's `.swarm/` is torn down with the worktree,
+ * which is exactly why the same information is also emitted as a deferred
+ * warning that survives into `/swarm diagnose`.
+ */
+function recordLanePermissionEvent(
+	directory: string,
+	event: Record<string, unknown>,
+): void {
+	try {
+		const eventsPath = validateSwarmPath(directory, 'events.jsonl');
+		_internals.mkdirSync(path.dirname(eventsPath), { recursive: true });
+		_internals.appendFileSync(
+			eventsPath,
+			`${JSON.stringify(event)}\n`,
+			'utf-8',
+		);
+	} catch {
+		// Intentionally swallowed — see doc comment.
+	}
+}
+
+/**
+ * Applies scoped lane permissions to an OpenCode config object, in place.
+ *
+ * Called from the plugin `config` hook. When `directory` is not a swarm
+ * worktree lane this returns immediately and mutates NOTHING — ordinary
+ * sessions must be byte-for-byte unaffected, which
+ * `tests/unit/config/lane-permissions-config.test.ts` asserts directly.
+ *
+ * @param opencodeConfig - The live merged config object the host handed to the
+ *                         `config` hook. Mutated in place, as the hook contract
+ *                         requires.
+ * @param directory      - The plugin's own `ctx.directory`. Under this host that
+ *                         IS the instance directory, so in a lane instance it is
+ *                         the lane path.
+ * @param mode           - Configured `worktree.lane_permissions` policy.
+ * @returns What was decided, for logging and tests.
+ */
+export function applyLanePermissions(
+	opencodeConfig: Record<string, unknown>,
+	directory: string,
+	mode: LanePermissionMode,
+): LanePermissionApplication {
+	const lane = _internals.resolveLaneContext(directory);
+	if (!lane) return { lane: false };
+	// AGENTS.md invariant 4: `.swarm/` lives at the project root, never under a
+	// source subdirectory. An OpenCode instance can be bound BELOW a lane root
+	// (that is why resolveLaneContext walks ancestors), and using `directory`
+	// here would write `<lane>/src/.swarm/events.jsonl`. Always anchor to the
+	// lane root.
+	const eventRoot = lane.lanePath;
+	if (mode === 'off') {
+		// Explicitly opted out: record the decision so the hang is diagnosable,
+		// but change nothing.
+		recordLanePermissionEvent(eventRoot, {
+			event: 'lane_permissions',
+			timestamp: new Date().toISOString(),
+			decision: 'skipped',
+			mode,
+			lanePath: lane.lanePath,
+			parentProjectPath: lane.parentProjectPath,
+			reason:
+				'worktree.lane_permissions is "off"; external_directory asks in this lane cannot be answered and will hang',
+		});
+		return { lane: true, mode };
+	}
+
+	const permission = ((): Record<string, unknown> => {
+		const current = opencodeConfig.permission;
+		if (current && typeof current === 'object' && !Array.isArray(current)) {
+			return current as Record<string, unknown>;
+		}
+		const created: Record<string, unknown> = {};
+		opencodeConfig.permission = created;
+		return created;
+	})();
+
+	// Per-agent `permission` is merged by the host AFTER the top-level block
+	// (`e.permission = a.merge(e.permission, a.fromConfig(s.permission ?? {}))`),
+	// so an `ask` left in any agent's own external_directory would outrank the
+	// top-level coercion below and reinstate the hang for that agent. Sweep
+	// those too.
+	const agentCoerced = downgradeAgentAskRules(opencodeConfig);
+
+	const allowlist =
+		mode === 'scoped_allow'
+			? buildLaneAllowlist(lane, readConfiguredSkillPaths(opencodeConfig))
+			: [];
+	const build = buildLaneExternalDirectoryRules(
+		mode,
+		lane,
+		permission.external_directory,
+		allowlist,
+	);
+	// `mode` is not 'off' here, so buildLaneExternalDirectoryRules never returns
+	// null; the guard keeps the types honest without an assertion.
+	if (!build) return { lane: true, mode };
+
+	const { rules, coercedAskPatterns: topLevelCoerced } = build;
+	permission.external_directory = rules;
+
+	const coercedAskPatterns = [...topLevelCoerced, ...agentCoerced];
+	_internals.addDeferredWarning(
+		renderLanePermissionAdvisory(mode, lane, allowlist, coercedAskPatterns),
+	);
+	recordLanePermissionEvent(eventRoot, {
+		event: 'lane_permissions',
+		timestamp: new Date().toISOString(),
+		decision: 'applied',
+		mode,
+		lanePath: lane.lanePath,
+		parentProjectPath: lane.parentProjectPath,
+		allowlist: allowlist.map((entry) => ({
+			pattern: entry.pattern,
+			reason: entry.reason,
+		})),
+		rules,
+		coercedAskPatterns,
+		remedy:
+			'Add { "permission": { "external_directory": { "<absolute-dir>/*": "allow" } } } to opencode.json to widen the allowlist.',
+	});
+
+	return { lane: true, mode, rules };
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -2414,6 +2414,35 @@ export const WorktreeIsolationConfigSchema = z.object({
 	worktree_dir: z.string().optional(),
 	deps_strategy: z.enum(['skip', 'copy', 'link']).default('skip'),
 	/**
+	 * Permission policy for OpenCode instances running inside a swarm worktree
+	 * lane. OpenCode partitions permission state per directory, so a lane gets
+	 * an empty `approved` list and a private pending map; because no TUI is
+	 * attached to a lane instance, an `external_directory` prompt raised there
+	 * can never be answered and the lane hangs indefinitely.
+	 *
+	 * scoped_allow: (default) pre-grant `external_directory` access to a
+	 * justified allowlist — the parent project the lane is a worktree of, the
+	 * plugin config/cache dirs, the OS temp dir, and the configured skill roots
+	 * — and deny everything else outright so nothing can be left pending.
+	 *
+	 * deny: emit no allowlist at all — only the catch-all deny. Anything you
+	 * have explicitly allowed in `permission.external_directory` still applies
+	 * (user configuration is merged last and always wins), so this denies
+	 * everything the plugin would otherwise have granted, not literally every
+	 * request. Still resolves rather than hanging.
+	 *
+	 * off: apply no lane-specific permission rules. This RESTORES the hanging
+	 * behaviour described above — an unanswerable prompt in a lane will block
+	 * that lane until the server is restarted. Provided only as an escape hatch
+	 * for hosts where the scoped rules are undesirable.
+	 *
+	 * Has no effect outside a swarm worktree lane; ordinary sessions are never
+	 * modified by this setting.
+	 */
+	lane_permissions: z
+		.enum(['scoped_allow', 'deny', 'off'])
+		.default('scoped_allow'),
+	/**
 	 * FR-104 SC-111: Release a serialized session after this many successful
 	 * dispatches have completed and merged back from that session.
 	 */

--- a/src/config/swarm-branch.ts
+++ b/src/config/swarm-branch.ts
@@ -1,0 +1,215 @@
+/**
+ * The swarm worktree BRANCH GRAMMAR — single source of truth for both building
+ * and recognising the branch names that identify a swarm-owned worktree.
+ *
+ * ## Why a grammar and not a prefix
+ *
+ * Lane detection (`src/config/lane-context.ts`) uses the branch name as its
+ * ownership signal because, unlike the worktree's path, it is invariant across
+ * all three provisioning layouts (default `.swarm-worktrees`, a configured
+ * `worktree.worktree_dir`, and the Windows path-budget fallback that relocates
+ * a lane to `<os.tmpdir()>/swwt/...`).
+ *
+ * Matching a bare `swarm/` PREFIX is not safe. A user running
+ * `git worktree add -b swarm/my-own-experiment ../scratch` would be classified
+ * as a lane, and their ordinary interactive session would then have
+ * `external_directory: { "*": "deny", ... }` injected. That is strictly worse
+ * than the hang this subsystem exists to fix, because the host's
+ * `Permission.ask` short-circuits on a deny before it ever creates a deferred:
+ *
+ * ```js
+ * // opencode 1.18.10, Permission.ask
+ * if (W.action === "deny") return yield* new U.DeniedError({ ... });
+ * ```
+ *
+ * — so no prompt is raised and "Allow always" can never be reached. The user
+ * has no in-session recovery.
+ *
+ * The grammar below therefore matches the COMPLETE shape
+ * `makeWorktreeBranchName` emits, including a session segment constrained to
+ * OpenCode's `ses_`-prefixed identifier form. `tests/unit/config/swarm-branch.test.ts`
+ * holds a round-trip property test over the producer and a negative corpus of
+ * plausible human-authored branch names.
+ *
+ * @module config/swarm-branch
+ */
+
+import { SWARM_WORKTREE_DIR_NAME } from './constants';
+
+/**
+ * Branch-name prefixes emitted by `makeWorktreeBranchName`.
+ *
+ * `swarm/` is the standard purpose-scoped style; `swarm-lane/` is Lean Turbo's
+ * `branchStyle: 'legacy-lane'`.
+ */
+const SWARM_WORKTREE_BRANCH_PREFIXES = ['swarm/', 'swarm-lane/'] as const;
+
+/**
+ * OpenCode session identifiers are `ses_` followed by an alphanumeric body
+ * (e.g. `ses_0410b724cffeApmZIOs5VH9XsN`). Constraining the session segment is
+ * what stops `swarm/lane/notasession/1.1` from matching.
+ */
+const SESSION_ID_PATTERN = /^ses_[A-Za-z0-9]+$/;
+
+/**
+ * True when `sessionId` is a session identifier the lane grammar can encode.
+ *
+ * Tool arguments are LLM-supplied (`sessionID: z.string()`) and the host's own
+ * `SessionID` brand is only `isStartsWith("ses")`, so a value like `ses-run-1`
+ * passes the host but yields a branch the recogniser cannot match — a lane that
+ * silently skips permission scoping and hangs. Callers that accept a session id
+ * from outside should check this before provisioning.
+ */
+export function isSwarmSessionId(sessionId: unknown): sessionId is string {
+	return typeof sessionId === 'string' && SESSION_ID_PATTERN.test(sessionId);
+}
+
+/**
+ * A single path segment that is neither empty nor a relative-path token.
+ * Applied to `<purpose>` and `<id>` so no segment can smuggle in traversal.
+ */
+function isPlainSegment(segment: string | undefined): segment is string {
+	return (
+		typeof segment === 'string' &&
+		segment.length > 0 &&
+		segment !== '.' &&
+		segment !== '..'
+	);
+}
+
+/**
+ * Builds the branch name for a swarm worktree.
+ *
+ * The ONLY producer of these names. `makeWorktreeBranchName` in
+ * `src/worktree/core.ts` delegates here so the producer and
+ * {@link matchSwarmLaneBranch} cannot drift.
+ *
+ * @param sessionId    - Parent session identifier.
+ * @param id           - Execution-unit identifier (task or lane id).
+ * @param purpose      - Worktree purpose (e.g. `lane`).
+ * @param legacyLane   - Use Lean Turbo's `swarm-lane/<sessionId>/<id>` style.
+ */
+export function buildSwarmBranchName(
+	sessionId: string,
+	id: string,
+	purpose: string,
+	legacyLane: boolean,
+): string {
+	const [standardPrefix, legacyLanePrefix] = SWARM_WORKTREE_BRANCH_PREFIXES;
+	return legacyLane
+		? `${legacyLanePrefix}${sessionId}/${id}`
+		: `${standardPrefix}${purpose}/${sessionId}/${id}`;
+}
+
+/**
+ * Recognises the DEFAULT lane PATH shape,
+ * `<base>/.swarm-worktrees/<sessionId>/<id>`.
+ *
+ * This is the fallback ownership signal for a worktree whose HEAD is detached
+ * or unreadable, so its branch cannot be consulted. It must be as tight as the
+ * branch grammar: matching "any path containing a `.swarm-worktrees` segment"
+ * captures a user's own `git worktree add -b my-feature ../.swarm-worktrees/manual-user-wt`,
+ * which then has an unrecoverable deny-by-default injected into an ordinary
+ * interactive session.
+ *
+ * `provisionWorktree` builds this path as
+ * `path.resolve(resolveWorktreeBaseDir(directory), sessionId, id)`, i.e. exactly
+ * two segments after the base, so the shape check requires exactly that — with
+ * the session segment held to the SAME `ses_…` constraint the branch grammar
+ * uses. The directory name comes from the same `SWARM_WORKTREE_DIR_NAME`
+ * constant `resolveWorktreeBaseDir` builds with, so the three definitions
+ * cannot drift.
+ *
+ * KNOWN RESIDUAL (accepted, not a defect to chase): a worktree the USER created
+ * at exactly `<base>/.swarm-worktrees/ses_<alnum>/<id>` on a non-swarm branch
+ * still classifies as a lane. Reaching it requires deliberately creating a
+ * directory literally named `ses_<alnum>` under a `.swarm-worktrees` base, and
+ * the same leniency is what keeps a REAL lane detected after someone checks out
+ * a different branch inside it. Narrowing further would trade a far more likely
+ * false negative (a real lane silently unscoped, i.e. the original hang) for a
+ * far less likely false positive.
+ *
+ * Note this recognises only the DEFAULT layout. A `worktree_dir` override or
+ * the Windows path-budget fallback produces a different path, and a lane in
+ * those layouts with a detached HEAD is a false NEGATIVE — no permission
+ * changes, i.e. today's behaviour. That is the safe direction.
+ *
+ * @param lanePath - An already-resolved absolute path.
+ */
+export function matchSwarmLanePath(
+	lanePath: string,
+): { sessionId: string; id: string } | undefined {
+	if (typeof lanePath !== 'string' || lanePath === '') return undefined;
+	const segments = lanePath.split(/[\\/]+/).filter((s) => s.length > 0);
+	if (segments.length < 3) return undefined;
+	const [base, sessionId, id] = segments.slice(-3);
+	// Windows path comparison is case-insensitive; POSIX is not.
+	const baseMatches =
+		process.platform === 'win32'
+			? base.toLowerCase() === SWARM_WORKTREE_DIR_NAME.toLowerCase()
+			: base === SWARM_WORKTREE_DIR_NAME;
+	if (!baseMatches) return undefined;
+	if (!SESSION_ID_PATTERN.test(sessionId ?? '')) return undefined;
+	if (!isPlainSegment(id)) return undefined;
+	return { sessionId, id };
+}
+
+/** A branch name recognised as a swarm worktree lane. */
+export interface SwarmLaneBranch {
+	/** Worktree purpose. `'lane'` for the legacy style, which encodes no purpose. */
+	purpose: string;
+	sessionId: string;
+	id: string;
+	style: 'purpose' | 'legacy-lane';
+}
+
+/**
+ * Recognises a branch name produced by {@link buildSwarmBranchName}.
+ *
+ * Matches the complete grammar and nothing wider:
+ *   - `swarm/<purpose>/<sessionId>/<id>`   — exactly 4 segments
+ *   - `swarm-lane/<sessionId>/<id>`        — exactly 3 segments
+ *
+ * with `<sessionId>` matching `ses_[A-Za-z0-9]+` and `<purpose>` / `<id>` each
+ * a single non-empty, non-dot segment. Anything else — including a bare
+ * `swarm/my-own-experiment`, or a real lane name with extra trailing segments —
+ * returns `undefined`, which classifies the worktree as NOT swarm-owned and
+ * leaves it completely untouched.
+ *
+ * @returns The parsed branch, or `undefined` when the name is not a swarm lane.
+ */
+export function matchSwarmLaneBranch(
+	branch: string,
+): SwarmLaneBranch | undefined {
+	if (typeof branch !== 'string' || branch === '') return undefined;
+	const segments = branch.split('/');
+
+	// swarm-lane/<sessionId>/<id>
+	if (segments[0] === 'swarm-lane') {
+		if (segments.length !== 3) return undefined;
+		const [, sessionId, id] = segments;
+		if (!SESSION_ID_PATTERN.test(sessionId ?? '')) return undefined;
+		if (!isPlainSegment(id)) return undefined;
+		return { purpose: 'lane', sessionId, id, style: 'legacy-lane' };
+	}
+
+	// swarm/<purpose>/<sessionId>/<id>
+	if (segments[0] === 'swarm') {
+		if (segments.length !== 4) return undefined;
+		const [, purpose, sessionId, id] = segments;
+		if (!isPlainSegment(purpose)) return undefined;
+		if (!SESSION_ID_PATTERN.test(sessionId ?? '')) return undefined;
+		if (!isPlainSegment(id)) return undefined;
+		return { purpose, sessionId, id, style: 'purpose' };
+	}
+
+	return undefined;
+}
+
+/**
+ * Tier-0 test seam (writing-tests skill). The prefix list is an implementation
+ * detail of the grammar — production code goes through
+ * {@link buildSwarmBranchName} / {@link matchSwarmLaneBranch} — but the branch
+ * tests assert that both documented styles are actually exercised.
+ */
+export const _test_exports = { SWARM_WORKTREE_BRANCH_PREFIXES };

--- a/src/hooks/init-orphan-recovery.ts
+++ b/src/hooks/init-orphan-recovery.ts
@@ -22,6 +22,7 @@ import {
 	scanDelegationFallbacksForRecovery,
 	scanDelegationsForRecovery,
 } from '../background/pending-delegations.js';
+import { SWARM_WORKTREE_DIR_NAME } from '../config/constants';
 import {
 	isLocked,
 	listActiveLocks,
@@ -191,7 +192,7 @@ async function enumerateOrphanedWorktreeDirs(
 	const orphanedDirs: string[] = [];
 	const worktreeRoot = path.resolve(
 		path.dirname(directory),
-		'.swarm-worktrees',
+		SWARM_WORKTREE_DIR_NAME,
 	);
 
 	let entries: fs.Dirent[];

--- a/src/hooks/skill-propagation-gate.ts
+++ b/src/hooks/skill-propagation-gate.ts
@@ -225,8 +225,16 @@ export const SKILL_CAPABLE_AGENTS = new Set([
 	'designer',
 ]);
 
-/** Skill root directories to scan for SKILL.md files. */
-const SKILL_SEARCH_ROOTS = [
+/**
+ * Skill root directories to scan for SKILL.md files.
+ *
+ * Exported because `src/config/lane-permissions.ts` resolves these same
+ * project-relative roots to absolute directories when building the
+ * `external_directory` allowlist for a worktree-lane instance. Keeping one
+ * definition means a new skill root cannot be added here and silently become
+ * an unanswerable permission prompt inside a lane.
+ */
+export const SKILL_SEARCH_ROOTS = [
 	'.opencode/skills',
 	'.opencode/skills/generated',
 	'.claude/skills',

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,7 @@ export function capSessionMap<K, V>(map: Map<K, V>, max: number): void {
 	}
 }
 
+import { applyLanePermissions } from './config/lane-permissions.js';
 import {
 	addDeferredWarning,
 	advisoryWarn,
@@ -1427,6 +1428,7 @@ async function initializeOpenCodeSwarm(
 	let preflightTriggerManager: PreflightTriggerManager | undefined;
 	let statusArtifact: AutomationStatusArtifact | undefined;
 	let prMonitorWorker: PrMonitorWorker | null = null;
+	let planSyncWorker: PlanSyncWorker | null = null;
 
 	if (automationConfig.mode !== 'manual') {
 		automationManager = createAutomationManager(automationConfig);
@@ -1488,7 +1490,7 @@ async function initializeOpenCodeSwarm(
 		// v6.8 Task 3.2: Wire PlanSyncWorker for plan.json -> plan.md sync
 		if (automationConfig.capabilities?.plan_sync === true) {
 			try {
-				const planSyncWorker = new PlanSyncWorker({
+				planSyncWorker = new PlanSyncWorker({
 					directory: ctx.directory,
 					// Using defaults: debounceMs=300, pollIntervalMs=2000
 				});
@@ -1613,6 +1615,7 @@ async function initializeOpenCodeSwarm(
 	const cleanupAutomation = () => {
 		automationManager?.stop();
 		prMonitorWorker?.stop();
+		planSyncWorker?.stop();
 		prEventCleanup?.();
 		prEventDelivery?.unregisterPrEventDelivery();
 	};
@@ -1894,6 +1897,40 @@ async function initializeOpenCodeSwarm(
 
 			// Merge agent configs (don't override default_agent)
 			Object.assign(agentConfig, agents);
+
+			// Worktree-lane permission scoping.
+			//
+			// OpenCode partitions permission state per directory, and `Plugin.state`
+			// is built through the same directory-keyed InstanceState cache as
+			// `Permission.state` — so when this hook runs inside a lane instance,
+			// `ctx.directory` IS the lane path. Pre-resolving `external_directory`
+			// here prevents the ask from ever being raised, which matters because a
+			// lane instance has no TUI that could answer one (the host's
+			// `Permission.ask` awaits its deferred with no timeout).
+			//
+			// A no-op for every ordinary session: `applyLanePermissions` mutates
+			// nothing unless the directory resolves as a swarm worktree lane.
+			// Wrapped because a config-hook throw is logged and ignored by the host
+			// (`tryPromise` + `tapError` + `ignore`), which would silently drop the
+			// agent registration work above on some future refactor.
+			try {
+				// Read straight off `config` rather than via
+				// `resolveWorktreeIsolationConfig`: that resolver is a spread over
+				// DEFAULT_WORKTREE_ISOLATION_CONFIG whose `lane_permissions` default
+				// is this same 'scoped_allow', so the two are behaviourally
+				// identical here — and the direct read keeps this hook off the
+				// resolver's import chain. Do not "simplify" it into that import
+				// without re-checking the init-path cost.
+				applyLanePermissions(
+					opencodeConfig,
+					ctx.directory,
+					config?.worktree?.lane_permissions ?? 'scoped_allow',
+				);
+			} catch (err) {
+				addDeferredWarning(
+					`[swarm] lane permission scoping failed: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
 
 			// Auto-select architect: disable competing built-in agents when enabled
 			const autoSelect = config?.auto_select_architect;

--- a/src/tools/epic-run-phase.ts
+++ b/src/tools/epic-run-phase.ts
@@ -26,6 +26,7 @@
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
 import { loadPluginConfigWithMeta as loadPluginConfigWithMeta_import } from '../config/index.js';
+import { isSwarmSessionId } from '../config/swarm-branch.js';
 import { isGitRepo as isGitRepo_import } from '../git/branch.js';
 import { loadPlanJsonOnly as loadPlanJsonOnly_import } from '../plan/manager.js';
 import { swarmState } from '../state.js';
@@ -673,6 +674,32 @@ export const epic_decide_phase: ToolDefinition = createSwarmTool({
 		const { phase, sessionID: argSessionID } = args as EpicRunPhaseArgs;
 		const sessionID =
 			ctx?.sessionID && ctx.sessionID.length > 0 ? ctx.sessionID : argSessionID;
+		// This is the `epic_decide_phase` tool. When ctx carries no session id we
+		// fall back to the model-supplied argument, which is `z.string()`.
+		//
+		// What this guard does NOT do: protect lane provisioning.
+		// `executeEpicDecidePhase` uses `sessionID` only as a lookup key —
+		// `isEpicModeActive` (:170) and `recordEpicDecision` (:511) — and never
+		// reaches `provisionWorktree`. (The `LeanTurboRunner` construction lower
+		// in this file belongs to `executeEpicRunPhase`, which has no
+		// ToolDefinition; see the note above it.) The lane-provisioning guard for
+		// that path is in `provisionWorktree` itself.
+		//
+		// What it DOES do: turn an unencodable session id into a precise error
+		// instead of a misleading one. Without it, `isEpicModeActive` simply
+		// returns false for the bogus key and the tool reports "epic mode is not
+		// active for this session" — which is wrong-sounding when epic mode IS
+		// active, just under the real id.
+		if (!isSwarmSessionId(sessionID)) {
+			return JSON.stringify(
+				{
+					ok: false,
+					error: `Invalid sessionID "${sessionID}". It must look like "ses_" followed by letters/digits. Omit the argument so the tool can use the active session id.`,
+				},
+				null,
+				2,
+			);
+		}
 		const result = await executeEpicDecidePhase({
 			phase,
 			sessionID,

--- a/src/tools/lean-turbo-run-phase.ts
+++ b/src/tools/lean-turbo-run-phase.ts
@@ -6,6 +6,7 @@
 import type { ToolDefinition } from '@opencode-ai/plugin/tool';
 import { z } from 'zod';
 import { loadPluginConfigWithMeta as loadPluginConfigWithMeta_import } from '../config';
+import { isSwarmSessionId } from '../config/swarm-branch';
 import { swarmState } from '../state';
 import type { LaneResult, MergeBackFailureInfo } from '../turbo/lean/runner';
 import { LeanTurboRunner as LeanTurboRunner_import } from '../turbo/lean/runner';
@@ -147,8 +148,28 @@ export function createLeanTurboRunPhaseTool(
 			phase: z.number().int().positive().describe('Phase number to execute'),
 			sessionID: z.string().describe('Lean Turbo session ID'),
 		},
-		execute: async (args: unknown, _directory: string) => {
-			const { phase, sessionID } = args as LeanTurboRunPhaseArgs;
+		execute: async (args: unknown, _directory: string, ctx) => {
+			const { phase, sessionID: argSessionID } = args as LeanTurboRunPhaseArgs;
+			// Prefer the REAL session id from the tool context over the
+			// model-supplied argument (mirrors epic_run_phase). The argument is
+			// `z.string()`, so an LLM can pass anything; it reaches
+			// provisionWorktree -> buildSwarmBranchName and a value such as
+			// `ses-run-1` produces a branch lane detection cannot recognise,
+			// silently skipping permission scoping and reinstating the hang.
+			const sessionID =
+				ctx?.sessionID && ctx.sessionID.length > 0
+					? ctx.sessionID
+					: argSessionID;
+			if (!isSwarmSessionId(sessionID)) {
+				return JSON.stringify(
+					{
+						ok: false,
+						error: `Invalid sessionID "${sessionID}". It must look like "ses_" followed by letters/digits. Omit the argument so the tool can use the active session id.`,
+					},
+					null,
+					2,
+				);
+			}
 			// Use _directory from tool context for .swarm containment (invariant #4)
 			return JSON.stringify(
 				await executeLeanTurboRunPhase(

--- a/src/worktree/core.ts
+++ b/src/worktree/core.ts
@@ -13,6 +13,11 @@ import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { SWARM_WORKTREE_DIR_NAME } from '../config/constants';
+import {
+	buildSwarmBranchName,
+	matchSwarmLaneBranch,
+} from '../config/swarm-branch';
 import { advisoryWarn } from '../services/warning-buffer';
 import { log } from '../utils';
 import { bunSpawn } from '../utils/bun-compat';
@@ -458,10 +463,16 @@ export function makeWorktreeBranchName(
 	id: string,
 	options: Pick<WorktreeOptions, 'purpose' | 'branchStyle'>,
 ): string {
-	if (options.branchStyle === 'legacy-lane' && options.purpose === 'lane') {
-		return `swarm-lane/${sessionId}/${id}`;
-	}
-	return `swarm/${options.purpose}/${sessionId}/${id}`;
+	// Delegates to the shared grammar in src/config/swarm-branch.ts so that this
+	// producer and the lane-detection recogniser (matchSwarmLaneBranch) cannot
+	// drift. A new naming style must be added to that grammar, or lanes using it
+	// become invisible to lane-permission scoping.
+	return buildSwarmBranchName(
+		sessionId,
+		id,
+		options.purpose,
+		options.branchStyle === 'legacy-lane' && options.purpose === 'lane',
+	);
 }
 
 /**
@@ -502,7 +513,7 @@ export function resolveWorktreeBaseDir(
 ): string {
 	return worktreeDir
 		? path.resolve(directory, worktreeDir)
-		: path.resolve(path.dirname(directory), '.swarm-worktrees');
+		: path.resolve(path.dirname(directory), SWARM_WORKTREE_DIR_NAME);
 }
 
 /**
@@ -562,6 +573,35 @@ export async function provisionWorktree(
 	options: WorktreeOptions,
 ): Promise<WorktreeProvisionResult> {
 	const branchName = makeWorktreeBranchName(sessionId, id, options);
+
+	// STRUCTURAL GUARD — a lane whose branch the recogniser cannot match is a
+	// lane that will HANG.
+	//
+	// Lane permission scoping (src/config/lane-context.ts) identifies a lane by
+	// its branch. If we provision one whose branch falls outside the grammar,
+	// detection silently returns "not a lane", no permissions are pre-resolved,
+	// and the first external_directory request in that lane parks forever on a
+	// deferred no TUI can answer — the exact defect this subsystem exists to
+	// remove, reintroduced silently.
+	//
+	// The realistic source is an unvalidated `sessionId`: tool arguments are
+	// LLM-supplied (`sessionID: z.string()`), and the host's own `SessionID`
+	// brand is only `isStartsWith("ses")`, so a value like `ses-run-1` reaches
+	// here intact. Asserting at the provisioning boundary makes the defect
+	// unreachable no matter where the id came from.
+	//
+	// Hard failure, not a warning: silently creating an unrecognisable lane is
+	// strictly worse than refusing to create one.
+	if (!matchSwarmLaneBranch(branchName)) {
+		return {
+			error:
+				`Refusing to provision worktree: branch "${branchName}" does not match the swarm lane grammar, ` +
+				`so lane permission scoping could not recognise it and the lane would hang on the first ` +
+				`external-directory prompt. This is almost always an invalid sessionId ("${sessionId}"); ` +
+				`it must look like "ses_" followed by letters/digits, and the execution-unit id ("${id}") ` +
+				`must be a single path segment.`,
+		};
+	}
 
 	// Resolve worktree path: explicit config or DD-6 default
 	let worktreePath = path.resolve(

--- a/tests/helpers/lane-permissions-fixture.ts
+++ b/tests/helpers/lane-permissions-fixture.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared fixture for the `lane-permissions` test files.
+ *
+ * Extracted when `lane-permissions.test.ts` crossed the FR-006 500-line cap and
+ * was split into allowlist CONSTRUCTION (`lane-permissions.test.ts`) and rule
+ * PRECEDENCE (`lane-permissions-precedence.test.ts`). Both files need the same
+ * lane and the same two thin wrappers, so this is the split protocol's
+ * preferred "extract to a shared utility" option rather than duplication.
+ *
+ * Contains no assertions and no mocks — it is pure data plus two pass-throughs,
+ * so it cannot introduce cross-file mock leakage.
+ */
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { LaneContext } from '../../src/config/lane-context';
+import { _test_exports } from '../../src/config/lane-permissions';
+
+export const { buildLaneAllowlist, buildLaneExternalDirectoryRules } =
+	_test_exports;
+
+export const lane: LaneContext = {
+	lanePath: path.resolve(
+		path.join(os.tmpdir(), 'wt', '.swarm-worktrees', 's', '1.1'),
+	),
+	parentProjectPath: path.resolve(path.join(os.tmpdir(), 'wt', 'my-project')),
+};
+
+/** Builds rules, unwrapping the {rules, coercedAskPatterns} envelope. */
+export function build(
+	mode: 'scoped_allow' | 'deny' | 'off',
+	existing?: unknown,
+): Record<string, string> | null {
+	const out = buildLaneExternalDirectoryRules(mode, lane, existing);
+	return out ? out.rules : null;
+}
+
+/** Wraps rules the way `applyLanePermissions` writes them into the config. */
+export function asPermission(
+	rules: Record<string, string> | null,
+): Record<string, unknown> {
+	return rules ? { external_directory: rules } : {};
+}

--- a/tests/helpers/opencode-permission-model.ts
+++ b/tests/helpers/opencode-permission-model.ts
@@ -1,0 +1,213 @@
+/**
+ * Re-implementation of OpenCode's permission evaluation, transcribed from the
+ * shipped host binary so tests verify our emitted rules against real host
+ * semantics instead of against our own assumptions.
+ *
+ * The four PRIMITIVES below (`hostWildcardMatch`, `hostFromConfig`,
+ * `hostMerge`, `hostEvaluate`) are verbatim transcriptions. `hostAgentRuleset`
+ * is a COMPOSITION of them modelling the host's agent assembly: it is faithful
+ * to the merge order and the tool-output re-append, but the caller must supply
+ * the host's base-allowed directories, because those are resolved at runtime by
+ * services this helper deliberately does not model.
+ *
+ * Source: `C:\OpenCode\opencode.exe`, opencode 1.18.10.
+ *
+ *  - `Wildcard.match`  — offset 100456759
+ *  - `Permission.evaluate` / `fromConfig` / `merge` — offset 102984993
+ *  - agent ruleset assembly (`l`, per-agent merge, tool-output append)
+ *    — offsets 100811506 and 100814474
+ *
+ * Verbatim host source for the three load-bearing functions:
+ *
+ * ```js
+ * function ql(e,o){ if(e)e=e.replaceAll("\\","/"); if(o)o=o.replaceAll("\\","/");
+ *   let l=o.replace(/[.+^${}()|[\]\\]/g,"\\$&").replace(/\*​/g,".*").replace(/\?/g,".");
+ *   if(l.endsWith(" .*"))l=l.slice(0,-3)+"( .*)?";
+ *   let i="si"; return new RegExp("^"+l+"$",i).test(e) }
+ *
+ * function RA(j){ let J=[]; for(let[K,z]of Object.entries(j)){
+ *   if(typeof z==="string"){J.push({permission:K,action:z,pattern:"*"});continue}
+ *   J.push(...Object.entries(z).map(([B,X])=>({permission:K,pattern:LA(B),action:X})))}
+ *   return J }
+ *
+ * function VA(...j){ return j.flat() }
+ *
+ * function c(j,J,...K){ return K.flat().findLast((z)=>
+ *   g.match(j,z.permission)&&g.match(J,z.pattern))
+ *   ?? {action:"ask",permission:j,pattern:"*"} }
+ * ```
+ *
+ * If a future OpenCode release changes any of these, the tests built on this
+ * helper are the tripwire — re-extract before "fixing" them.
+ */
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { hostNormalizePathPattern } from '../../src/config/host-path';
+
+export interface PermissionRule {
+	permission: string;
+	pattern: string;
+	action: string;
+}
+
+/** Host `Wildcard.match`. `pattern` is the RULE side; `value` is the asked side. */
+export function hostWildcardMatch(value: string, pattern: string): boolean {
+	const v = value ? value.replaceAll('\\', '/') : value;
+	const p = pattern ? pattern.replaceAll('\\', '/') : pattern;
+	let compiled = p
+		.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+		.replace(/\*/g, '.*')
+		.replace(/\?/g, '.');
+	if (compiled.endsWith(' .*')) compiled = `${compiled.slice(0, -3)}( .*)?`;
+	return new RegExp(`^${compiled}$`, 'si').test(v);
+}
+
+/** Host `LA` — the `~` / `$HOME` expansion applied to rule patterns. */
+function expandHome(p: string): string {
+	if (p.startsWith('~/')) return os.homedir() + p.slice(1);
+	if (p === '~') return os.homedir();
+	if (p.startsWith('$HOME')) return os.homedir() + p.slice(5);
+	return p;
+}
+
+/** Host `Permission.fromConfig`. Preserves `Object.entries` order. */
+export function hostFromConfig(
+	config: Record<string, unknown>,
+): PermissionRule[] {
+	const out: PermissionRule[] = [];
+	for (const [permission, value] of Object.entries(config)) {
+		if (typeof value === 'string') {
+			out.push({ permission, action: value, pattern: '*' });
+			continue;
+		}
+		for (const [pattern, action] of Object.entries(
+			value as Record<string, string>,
+		)) {
+			out.push({ permission, pattern: expandHome(pattern), action });
+		}
+	}
+	return out;
+}
+
+/** Host `Permission.merge` — plain concatenation. */
+export function hostMerge(...lists: PermissionRule[][]): PermissionRule[] {
+	return lists.flat();
+}
+
+/** Host `Permission.evaluate` — `findLast`, so LATER RULES WIN. */
+export function hostEvaluate(
+	permission: string,
+	askedPattern: string,
+	...rulesets: PermissionRule[][]
+): PermissionRule {
+	return (
+		rulesets
+			.flat()
+			.findLast(
+				(rule) =>
+					hostWildcardMatch(permission, rule.permission) &&
+					hostWildcardMatch(askedPattern, rule.pattern),
+			) ?? { action: 'ask', permission, pattern: '*' }
+	);
+}
+
+/**
+ * Builds the effective agent ruleset the way the host actually does.
+ *
+ * Faithful to `Agent.state` (offsets 100811506 and 100814474):
+ *
+ * ```js
+ * q = [A.GLOB, j.join(H.Path.tmp,"*"), ...y.map(n=>j.join(n,"*")),
+ *      ...b.map(n=>j.join(n,"*"))]                    // base-allowed dirs
+ * c = a.fromConfig({ ..., external_directory:{ "*":"ask",
+ *       ...Object.fromEntries(q.map(n=>[n,"allow"])) }, ... })
+ * l = a.fromConfig(config.permission ?? {})
+ * // per agent:  permission = a.merge(c, ..., l)
+ * //             then       = a.merge(permission, a.fromConfig(agent.permission))
+ * // finally the host appends external_directory:{ [A.GLOB]:"allow" } unless a
+ * // rule already has action==="deny" && pattern===A.GLOB exactly.
+ * ```
+ *
+ * The base allows matter: without them a test cannot distinguish "our rules
+ * deny what should be denied" from "our rules revoke something the host had
+ * already granted". Pass the host's base-allowed DIRECTORIES via
+ * `opts.baseAllowDirs` (patterns are derived as `<dir>/*`, as the host does).
+ */
+export function hostAgentRuleset(
+	topLevelPermission: Record<string, unknown>,
+	perAgentPermission: Record<string, unknown> = {},
+	opts: { baseAllowDirs?: readonly string[]; toolOutputGlob?: string } = {},
+): PermissionRule[] {
+	const baseAllows: Record<string, string> = { '*': 'ask' };
+	for (const dir of opts.baseAllowDirs ?? []) {
+		// The host derives these with `path.join(dir, '*')`; normalise them the
+		// same way the asked side is normalised so the model stays comparable.
+		baseAllows[hostNormalizePathPattern(path.join(dir, '*'))] = 'allow';
+	}
+	if (opts.toolOutputGlob) baseAllows[opts.toolOutputGlob] = 'allow';
+
+	const merged = hostMerge(
+		hostFromConfig({ external_directory: baseAllows }),
+		hostFromConfig(topLevelPermission),
+		hostFromConfig(perAgentPermission),
+	);
+
+	// Trailing re-append: unless an existing rule denies EXACTLY the tool-output
+	// glob, the host adds it back last.
+	if (opts.toolOutputGlob) {
+		const explicitlyDenied = merged.some(
+			(r) =>
+				r.permission === 'external_directory' &&
+				r.action === 'deny' &&
+				r.pattern === opts.toolOutputGlob,
+		);
+		if (!explicitlyDenied) {
+			return hostMerge(
+				merged,
+				hostFromConfig({
+					external_directory: { [opts.toolOutputGlob]: 'allow' },
+				}),
+			);
+		}
+	}
+	return merged;
+}
+
+/**
+ * The action the host would take for an `external_directory` request covering
+ * `directory`, given a top-level permission block.
+ *
+ * The asked pattern is produced exactly as the host's own producers do — e.g.
+ * `src/tools` (offset 100715012):
+ *
+ * ```js
+ * let u = G.normalizePathPattern(Hr.join(y, "*"));
+ * yield* o.ask({ permission: "external_directory", patterns: [u], … });
+ * ```
+ *
+ * A plain string concat here (the previous implementation) made every
+ * canonicalisation defect invisible to the suite: it silently agreed with an
+ * un-canonicalised rule, so a symlink/junction mismatch could never be
+ * observed. `hostNormalizePathPattern` is the transcription used by production
+ * too, which is the point — the assertion is that the rule text and the asked
+ * text CONVERGE under the host's own normaliser.
+ */
+export function evaluateExternalDirectory(
+	topLevelPermission: Record<string, unknown>,
+	directory: string,
+	opts: {
+		perAgentPermission?: Record<string, unknown>;
+		baseAllowDirs?: readonly string[];
+		toolOutputGlob?: string;
+	} = {},
+): string {
+	const asked = hostNormalizePathPattern(path.join(directory, '*'));
+	return hostEvaluate(
+		'external_directory',
+		asked,
+		hostAgentRuleset(topLevelPermission, opts.perAgentPermission ?? {}, {
+			baseAllowDirs: opts.baseAllowDirs,
+			toolOutputGlob: opts.toolOutputGlob,
+		}),
+	).action;
+}

--- a/tests/helpers/session-create-scanner.ts
+++ b/tests/helpers/session-create-scanner.ts
@@ -1,0 +1,305 @@
+/**
+ * Source scanner for the Phase 4.2 `session.create` guardrail.
+ *
+ * Extracted from `tests/unit/config/session-create-directory-guardrail.test.ts`
+ * to keep that file under the FR-006 500-line cap, and so the tokenizer can be
+ * exercised directly.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Blanks comments while preserving line numbering and byte offsets.
+ *
+ * This MUST understand string, template-literal and regex-literal context. A
+ * naive three-state (code/line/block) stripper treats the first `/*` inside a
+ * string literal as the start of a block comment and blanks the entire rest of
+ * the file — so any `session.create(` after it becomes invisible and the
+ * guardrail silently stops guarding. Seven files in `src/` contain such a
+ * literal today (glob patterns like `'**''/*.ts'`, `'/*'` in prose strings),
+ * including this feature's own `src/config/lane-permissions.ts`.
+ *
+ * The returned `state` must be `'code'` for well-formed TypeScript. Any other
+ * terminal state means the tokenizer lost track and the scan for that file is
+ * untrustworthy — {@link discoverSites} asserts on it rather than silently
+ * producing a short list.
+ */
+type StripState =
+	| 'code'
+	| 'line'
+	| 'block'
+	| 'single'
+	| 'double'
+	| 'template'
+	| 'regex';
+
+/**
+ * Characters/keywords after which a `/` begins a regex literal rather than a
+ * division operator. Standard heuristic; ambiguity in JS is unresolvable
+ * without a full parser, and the terminal-state assertion catches a mistake.
+ */
+const REGEX_PRECEDING_PUNCT = new Set([
+	'(',
+	',',
+	'=',
+	':',
+	'[',
+	'!',
+	'&',
+	'|',
+	'?',
+	'{',
+	'}',
+	';',
+	'\n',
+	'+',
+	'-',
+	'*',
+	'%',
+	'<',
+	'>',
+	'~',
+	'^',
+]);
+const REGEX_PRECEDING_KEYWORDS = [
+	'return',
+	'typeof',
+	'instanceof',
+	'in',
+	'of',
+	'new',
+	'delete',
+	'void',
+	'throw',
+	'do',
+	'else',
+	'yield',
+	'await',
+	'case',
+];
+
+/**
+ * Longest keyword in {@link REGEX_PRECEDING_KEYWORDS} is `instanceof` (10), plus
+ * a boundary char and trailing whitespace. 32 emitted characters is comfortably
+ * more than any decision needs.
+ */
+const REGEX_LOOKBEHIND = 32;
+
+/**
+ * Last few emitted characters, WITHOUT rebuilding the whole output buffer.
+ *
+ * `out.join('')` here was O(n) per `/` in code state, i.e. O(n^2) over a file —
+ * measured at 5.92 s across `src/`. The regex-start decision only ever looks at
+ * the trailing token, so a bounded tail is equivalent.
+ */
+function recentTail(out: readonly string[]): string {
+	let tail = '';
+	for (
+		let i = out.length - 1;
+		i >= 0 && tail.length < REGEX_LOOKBEHIND;
+		i -= 1
+	) {
+		tail = out[i] + tail;
+	}
+	return tail;
+}
+
+function regexCanStartHere(emitted: string): boolean {
+	const trimmed = emitted.replace(/\s+$/, '');
+	if (trimmed === '') return true;
+	const last = trimmed[trimmed.length - 1];
+	if (REGEX_PRECEDING_PUNCT.has(last)) return true;
+	return REGEX_PRECEDING_KEYWORDS.some((kw) =>
+		new RegExp(`(^|[^A-Za-z0-9_$])${kw}$`).test(trimmed),
+	);
+}
+
+export function stripCommentsWithState(source: string): {
+	source: string;
+	state: StripState;
+} {
+	const out: string[] = [];
+	// Nesting stack for `${ ... }` inside template literals: each entry counts
+	// open braces so the matching `}` returns to template context.
+	const templateStack: number[] = [];
+	let state: StripState = 'code';
+	let i = 0;
+	const blank = (c: string): string => (c === '\n' ? '\n' : ' ');
+
+	while (i < source.length) {
+		const c = source[i];
+		const next = source[i + 1] ?? '';
+
+		switch (state) {
+			case 'code': {
+				if (c === '/' && next === '*') {
+					state = 'block';
+					out.push('  ');
+					i += 2;
+					continue;
+				}
+				if (c === '/' && next === '/') {
+					state = 'line';
+					out.push('  ');
+					i += 2;
+					continue;
+				}
+				if (c === '/' && regexCanStartHere(recentTail(out))) {
+					state = 'regex';
+					out.push(c);
+					i += 1;
+					continue;
+				}
+				if (c === "'") state = 'single';
+				else if (c === '"') state = 'double';
+				else if (c === '`') state = 'template';
+				else if (c === '}' && templateStack.length > 0) {
+					const depth = templateStack[templateStack.length - 1];
+					if (depth === 0) {
+						templateStack.pop();
+						state = 'template';
+					} else {
+						templateStack[templateStack.length - 1] = depth - 1;
+					}
+				} else if (c === '{' && templateStack.length > 0) {
+					templateStack[templateStack.length - 1] += 1;
+				}
+				out.push(c);
+				i += 1;
+				continue;
+			}
+			case 'block': {
+				if (c === '*' && next === '/') {
+					state = 'code';
+					out.push('  ');
+					i += 2;
+					continue;
+				}
+				out.push(blank(c));
+				i += 1;
+				continue;
+			}
+			case 'line': {
+				if (c === '\n') {
+					state = 'code';
+					out.push('\n');
+					i += 1;
+					continue;
+				}
+				out.push(' ');
+				i += 1;
+				continue;
+			}
+			case 'single':
+			case 'double':
+			case 'template':
+			case 'regex': {
+				if (c === '\\') {
+					out.push(c, source[i + 1] ?? '');
+					i += 2;
+					continue;
+				}
+				if (state === 'template' && c === '$' && next === '{') {
+					templateStack.push(0);
+					state = 'code';
+					out.push('${');
+					i += 2;
+					continue;
+				}
+				const closer =
+					state === 'single'
+						? "'"
+						: state === 'double'
+							? '"'
+							: state === 'template'
+								? '`'
+								: '/';
+				if (c === closer) state = 'code';
+				// A newline terminates an unterminated single/double string or
+				// regex (a syntax error in real code); recover to `code` so one
+				// oddity cannot blank the remainder of the file.
+				else if (c === '\n' && state !== 'template') state = 'code';
+				out.push(c);
+				i += 1;
+				continue;
+			}
+		}
+	}
+	return { source: out.join(''), state };
+}
+
+function listSourceFiles(dir: string, acc: string[] = []): string[] {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+			listSourceFiles(full, acc);
+			continue;
+		}
+		if (!entry.name.endsWith('.ts')) continue;
+		if (entry.name.endsWith('.test.ts')) continue;
+		acc.push(full);
+	}
+	return acc;
+}
+
+export interface DiscoveredSite {
+	file: string;
+	line: number;
+	directoryExpr: string;
+}
+
+/** Extracts the balanced argument text of a `session.create(` call. */
+function callBody(source: string, startIndex: number): string {
+	let depth = 1;
+	let i = startIndex;
+	while (i < source.length && depth > 0) {
+		if (source[i] === '(') depth += 1;
+		else if (source[i] === ')') depth -= 1;
+		i += 1;
+	}
+	return source.slice(startIndex, i - 1);
+}
+
+function extractDirectoryExpr(body: string): string {
+	const explicit = /directory:\s*([A-Za-z0-9_$.[\]?!]+)/.exec(body);
+	if (explicit) return explicit[1];
+	// `query: { directory }` shorthand.
+	if (/\{\s*directory\s*[,}]/.test(body)) return 'directory';
+	// Helper form: `someHelper(firstArg, ...)`.
+	const helper = /([A-Za-z0-9_$]+)\(\s*([A-Za-z0-9_$.]+)/.exec(body.trim());
+	if (helper) return `HELPER ${helper[1]}(${helper[2]})`;
+	return 'UNRECOGNISED';
+}
+
+/** Files whose tokenizer terminal state was not `code` — see the assertion. */
+export const tokenizerFailures: string[] = [];
+
+export function discoverSites(srcRoot: string): DiscoveredSite[] {
+	const found: DiscoveredSite[] = [];
+	tokenizerFailures.length = 0;
+	for (const file of listSourceFiles(srcRoot)) {
+		const stripped = stripCommentsWithState(fs.readFileSync(file, 'utf-8'));
+		if (stripped.state !== 'code') {
+			tokenizerFailures.push(
+				`${path.relative(path.resolve(srcRoot, '..'), file).split(path.sep).join('/')} (ended in '${stripped.state}')`,
+			);
+		}
+		const source = stripped.source;
+		const pattern = /session\.create\(/g;
+		let match = pattern.exec(source);
+		while (match !== null) {
+			const body = callBody(source, match.index + match[0].length);
+			found.push({
+				file: path
+					.relative(path.resolve(srcRoot, '..'), file)
+					.split(path.sep)
+					.join('/'),
+				line: source.slice(0, match.index).split('\n').length,
+				directoryExpr: extractDirectoryExpr(body),
+			});
+			match = pattern.exec(source);
+		}
+	}
+	return found;
+}

--- a/tests/integration/cross-process-dispatch-path.test.ts
+++ b/tests/integration/cross-process-dispatch-path.test.ts
@@ -176,7 +176,7 @@ describe('SC-124: lane profile end-to-end via provisionWorktree() entry point', 
 		};
 
 		const laneId = 'lane-2'; // 0-based index = 1
-		const sessionId = 'test-session';
+		const sessionId = 'ses_testSession';
 
 		// provisionWorktree() from turbo/lean/worktree.ts:
 		// 1. Calls provisionSharedWorktree (git worktree add)
@@ -252,7 +252,7 @@ console.log('LANE_CUSTOM_VAR=' + (env.CUSTOM_VAR ?? 'UNSET'));
 				port_stride: 10,
 			},
 		};
-		const sessionId = 'multi-lane-session';
+		const sessionId = 'ses_multiLaneSession';
 
 		// Provision 3 lanes and verify each gets a distinct env file
 		for (let i = 0; i < 3; i++) {
@@ -305,7 +305,7 @@ console.log('LANE_CUSTOM_VAR=' + (env.CUSTOM_VAR ?? 'UNSET'));
 			const result = await provisionWorktree(
 				tmpDir,
 				laneId,
-				`session-${laneId}`,
+				`ses_lane${laneId.replace(/[^A-Za-z0-9]/g, '')}`,
 				config,
 			);
 

--- a/tests/integration/plan-sync-init.test.ts
+++ b/tests/integration/plan-sync-init.test.ts
@@ -10,7 +10,7 @@
  * 5. Gated by outer mode check (mode !== 'manual')
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
@@ -365,5 +365,107 @@ describe('PlanSyncWorker integration with plugin config', () => {
 			automationConfig.capabilities?.plan_sync === true;
 
 		expect(shouldInit).toBe(true);
+	});
+});
+
+describe('PlanSyncWorker lifecycle reachability — regression: dead cleanup path', () => {
+	// Previous code constructed the PlanSyncWorker into a block-scoped `const`
+	// inside the `if (automationConfig.capabilities?.plan_sync === true)`
+	// branch in src/index.ts. That const was never assigned to an outer-scope
+	// binding, so `cleanupAutomation` (registered on `process.on('exit', ...)`)
+	// could never reach it — `stop()`/`dispose()` were unreachable in
+	// production. This test proves the worker constructed by a real
+	// `OpenCodeSwarm.server()` call is the same instance whose `stop()` fires
+	// when the process-exit cleanup runs.
+	let testDir: string;
+	let xdgConfigHome: string;
+	let originalXdgConfigHome: string | undefined;
+
+	beforeEach(() => {
+		originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+		xdgConfigHome = mkdtempSync(path.join(tmpdir(), 'xdg-config-test-'));
+		process.env.XDG_CONFIG_HOME = xdgConfigHome;
+
+		testDir = mkdtempSync(path.join(tmpdir(), 'plan-sync-lifecycle-'));
+		const opencodeDir = path.join(testDir, '.opencode');
+		mkdirSync(opencodeDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (originalXdgConfigHome === undefined) {
+			delete process.env.XDG_CONFIG_HOME;
+		} else {
+			process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+		}
+		try {
+			rmSync(xdgConfigHome, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+		try {
+			rmSync(testDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	it('cleanupAutomation (registered via process.on("exit", ...)) calls PlanSyncWorker.stop()', async () => {
+		const configPath = path.join(testDir, '.opencode', 'opencode-swarm.json');
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				automation: {
+					mode: 'hybrid',
+					capabilities: { plan_sync: true },
+				},
+			}),
+		);
+
+		const { PlanSyncWorker } = await import(
+			'../../src/background/plan-sync-worker'
+		);
+		const OpenCodeSwarm = (await import('../../src/index')).default;
+
+		const stopSpy = spyOn(PlanSyncWorker.prototype, 'stop');
+
+		const mockPluginInput = {
+			client: {} as any,
+			project: {} as any,
+			directory: testDir,
+			worktree: testDir,
+			serverUrl: new URL('http://localhost:3000'),
+			$: {} as any,
+		};
+
+		// Capture only the 'exit' listener this server() call registers, rather
+		// than firing process.emit('exit') globally (which would also invoke
+		// every 'exit' listener left behind by other tests/files sharing this
+		// process — see AGENTS.md invariant 7 mock/test-isolation concerns).
+		const listenersBefore = process.listeners('exit').slice();
+
+		try {
+			await OpenCodeSwarm.server(mockPluginInput as any);
+
+			const addedListeners = process
+				.listeners('exit')
+				.filter((l) => !listenersBefore.includes(l));
+			expect(addedListeners.length).toBe(1);
+
+			expect(stopSpy).not.toHaveBeenCalled();
+
+			// Invoke exactly the listener this server() call registered —
+			// proves reachability of PlanSyncWorker.stop() from this init's own
+			// cleanupAutomation, without touching any other listener.
+			(addedListeners[0] as (...args: unknown[]) => void).call(process, 0);
+
+			expect(stopSpy).toHaveBeenCalled();
+		} finally {
+			stopSpy.mockRestore();
+			for (const l of process.listeners('exit')) {
+				if (!listenersBefore.includes(l)) {
+					process.removeListener('exit', l as (...args: unknown[]) => void);
+				}
+			}
+		}
 	});
 });

--- a/tests/unit/agents/getAgentConfigs-task-permission.test.ts
+++ b/tests/unit/agents/getAgentConfigs-task-permission.test.ts
@@ -1,10 +1,31 @@
-import { describe, expect, test } from 'bun:test';
-import { getAgentConfigs } from '../../../src/agents';
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+	type AgentDefinition,
+	_internals as agentInternals,
+	getAgentConfigs,
+} from '../../../src/agents';
 import type { PluginConfig } from '../../../src/config';
+import {
+	hostEvaluate,
+	hostFromConfig,
+} from '../../helpers/opencode-permission-model';
 
 // Helper to create minimal valid PluginConfig
 const minimalConfig = (partial: Partial<PluginConfig> = {}): PluginConfig =>
 	partial as PluginConfig;
+
+// Helper to build a synthetic AgentDefinition with an arbitrary `config`
+// shape (including malformed `permission` values for defensive tests).
+// Casts through `unknown` because callers intentionally construct shapes
+// the real `AgentConfig` type would reject (e.g. a non-object permission).
+const fakeAgent = (
+	name: string,
+	config: Record<string, unknown>,
+): AgentDefinition => ({
+	name,
+	description: `synthetic agent: ${name}`,
+	config: config as unknown as AgentDefinition['config'],
+});
 
 describe('getAgentConfigs - Architect Task Permission Hotfix', () => {
 	describe('architect agents get task:allow permission', () => {
@@ -164,5 +185,146 @@ describe('getAgentConfigs - Architect Task Permission Hotfix', () => {
 			expect(configs['coder'].tools?.swarm_command).toBe(true);
 			expect(configs['cloud_coder'].tools?.swarm_command).toBe(true);
 		});
+	});
+});
+
+/**
+ * Regression tests for the primary-agent permission clobber (src/agents/index.ts).
+ *
+ * `getAgentConfigs` used to REPLACE `sdkConfig.permission` wholesale when
+ * granting `task: 'allow'` to a primary agent:
+ *   `(sdkConfig.permission as Record<string, 'allow'>) = { task: 'allow' };`
+ * Any permission entries the agent's own definition already declared (edit,
+ * bash, webfetch, external_directory — including nested per-pattern
+ * objects) were silently discarded, and the cast defeated type checking.
+ *
+ * These tests inject a synthetic agent set via the `_internals.createAgents`
+ * DI seam (bun:test `mock.module` leaks across files in this repo's shared
+ * test-runner process — see AGENTS.md invariant 7) so we can construct an
+ * `AgentDefinition` whose `config.permission` is pre-populated, which no
+ * production `create*Agent` factory currently does.
+ */
+describe('getAgentConfigs - primary agent permission merge (not replace)', () => {
+	const realCreateAgents = agentInternals.createAgents;
+
+	afterEach(() => {
+		agentInternals.createAgents = realCreateAgents;
+	});
+
+	// Disabling tool_filter short-circuits getAgentConfigs before it reaches
+	// AGENT_TOOL_MAP lookups, which have no entry for these synthetic names.
+	const noToolFilterConfig = () =>
+		minimalConfig({ tool_filter: { enabled: false } });
+
+	test('primary agent keeps its own permission entries and gains task:allow', () => {
+		agentInternals.createAgents = () => [
+			fakeAgent('architect', {
+				permission: {
+					edit: 'deny',
+					external_directory: { 'C:/foo/*': 'allow' },
+				},
+			}),
+			fakeAgent('coder', { permission: { edit: 'deny' } }),
+		];
+
+		const configs = getAgentConfigs(noToolFilterConfig());
+
+		expect(configs.architect.mode).toBe('primary');
+		expect(configs.architect.permission).toEqual({
+			edit: 'deny',
+			external_directory: { 'C:/foo/*': 'allow' },
+			task: 'allow',
+		});
+	});
+
+	test('regression (LOW-5): task:allow is emitted LAST, not left in its old slot', () => {
+		// POSITION IS PRECEDENCE: the host evaluates permission with `findLast`
+		// over Object.entries order and wildcard-matches the permission NAME, so
+		// `'*'` also matches `task`. A duplicate key in an object literal keeps
+		// its FIRST position, so `{ ...{task:'deny','*':'deny'}, task:'allow' }`
+		// leaves `task` at index 0 and `findLast` picks `'*': 'deny'` — the
+		// primary agent silently loses delegation.
+		//
+		// `toEqual` does NOT compare key order, which is why this asserts
+		// Object.keys directly.
+		agentInternals.createAgents = () => [
+			fakeAgent('architect', {
+				permission: { task: 'deny', '*': 'deny' },
+			}),
+		];
+
+		const configs = getAgentConfigs(noToolFilterConfig());
+		const permission = configs.architect.permission as Record<string, string>;
+		const keys = Object.keys(permission);
+
+		expect(keys[keys.length - 1]).toBe('task');
+		expect(permission.task).toBe('allow');
+		// The wildcard the agent declared is preserved, just outranked for `task`.
+		expect(keys.indexOf('*')).toBeLessThan(keys.indexOf('task'));
+		expect(permission['*']).toBe('deny');
+	});
+
+	test('regression (LOW-5): a primary agent with a wildcard deny can still delegate', () => {
+		// The end-to-end property the key order exists to protect, evaluated
+		// through a faithful model of the host's own rule evaluation.
+		agentInternals.createAgents = () => [
+			fakeAgent('architect', {
+				permission: { task: 'deny', '*': 'deny' },
+			}),
+		];
+
+		const configs = getAgentConfigs(noToolFilterConfig());
+		const rules = hostFromConfig(
+			configs.architect.permission as Record<string, unknown>,
+		);
+		expect(hostEvaluate('task', '*', rules).action).toBe('allow');
+	});
+
+	test('task:allow wins when the agent definition also declares task', () => {
+		agentInternals.createAgents = () => [
+			fakeAgent('architect', { permission: { task: 'deny' } }),
+		];
+
+		const configs = getAgentConfigs(noToolFilterConfig());
+
+		expect(configs.architect.mode).toBe('primary');
+		expect(configs.architect.permission).toEqual({ task: 'allow' });
+	});
+
+	test('primary agent with no permission block gets exactly {task: allow}', () => {
+		agentInternals.createAgents = () => [fakeAgent('architect', {})];
+
+		const configs = getAgentConfigs(noToolFilterConfig());
+
+		expect(configs.architect.mode).toBe('primary');
+		expect(configs.architect.permission).toEqual({ task: 'allow' });
+	});
+
+	test("a subagent's own permission block is left untouched", () => {
+		agentInternals.createAgents = () => [
+			fakeAgent('architect', {}),
+			fakeAgent('coder', {
+				permission: { edit: 'deny', bash: { 'git *': 'allow' } },
+			}),
+		];
+
+		const configs = getAgentConfigs(noToolFilterConfig());
+
+		expect(configs.coder.mode).toBe('subagent');
+		expect(configs.coder.permission).toEqual({
+			edit: 'deny',
+			bash: { 'git *': 'allow' },
+		});
+	});
+
+	test('a non-object permission primitive does not throw and yields {task: allow}', () => {
+		agentInternals.createAgents = () => [
+			fakeAgent('architect', { permission: 'not-an-object' }),
+		];
+
+		expect(() => getAgentConfigs(noToolFilterConfig())).not.toThrow();
+		const configs = getAgentConfigs(noToolFilterConfig());
+		expect(configs.architect.mode).toBe('primary');
+		expect(configs.architect.permission).toEqual({ task: 'allow' });
 	});
 });

--- a/tests/unit/background/plan-sync-worker-unref.test.ts
+++ b/tests/unit/background/plan-sync-worker-unref.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression tests: PlanSyncWorker's poll timer must not hold the Bun/Node
+ * event loop open.
+ *
+ * Split out of plan-sync-worker.test.ts (already over the FR-006 500-line
+ * cap — the ratchet in scripts/check-test-file-cap.sh blocks growth of that
+ * file) rather than appended there.
+ *
+ * Deliberately does NOT touch fs.watch or wait on any watcher event — those
+ * are the timing-sensitive paths that force plan-sync-worker.test.ts to
+ * skip on non-Linux platforms. This file only asserts on the synchronous
+ * setInterval call inside start(), so it runs on every platform.
+ */
+import { describe, expect, spyOn, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { PlanSyncWorker } from '../../../src/background/plan-sync-worker';
+
+describe('PlanSyncWorker poll timer — regression: unref (issue: event-loop leak)', () => {
+	test('setupPolling() calls unref() on the interval timer so it cannot pin the event loop open', () => {
+		// Previous code did `this.pollTimer = setInterval(...)` and never called
+		// `.unref()` on the returned timer. A live, ref'd interval keeps the
+		// Node/Bun event loop from draining naturally, so `process.on('exit', ...)`
+		// cleanup never fires under normal (non-process.exit) shutdown.
+		// Clock-free unique name. A wall-clock timestamp would be a uniqueness
+		// source here, not a time-dependent assertion, so wrapping it in
+		// `freezeClock` would be wrong — a frozen clock makes "unique" names
+		// collide. `randomUUID` gives uniqueness without reading the clock at all,
+		// which also keeps scripts/check-test-clock.sh satisfied.
+		const directory = path.join(tmpdir(), `plan-sync-unref-${randomUUID()}`);
+		const worker = new PlanSyncWorker({
+			directory,
+			// Long interval — this test asserts on the setInterval call itself,
+			// never lets the callback fire.
+			pollIntervalMs: 1_000_000,
+		});
+
+		const realSetInterval = globalThis.setInterval;
+		let capturedTimer: { unref?: () => unknown } | undefined;
+		let unrefCallCount = 0;
+		const setIntervalSpy = spyOn(globalThis, 'setInterval').mockImplementation(
+			((fn: (...args: unknown[]) => void, ms?: number, ...args: unknown[]) => {
+				const timer = realSetInterval(fn, ms, ...args) as unknown as {
+					unref?: () => unknown;
+				};
+				const originalUnref = timer.unref?.bind(timer);
+				timer.unref = (...unrefArgs: unknown[]) => {
+					unrefCallCount++;
+					return originalUnref?.(...unrefArgs);
+				};
+				capturedTimer = timer;
+				return timer;
+			}) as typeof globalThis.setInterval,
+		);
+
+		try {
+			worker.start();
+
+			expect(capturedTimer).toBeDefined();
+			expect(unrefCallCount).toBe(1);
+		} finally {
+			worker.stop();
+			setIntervalSpy.mockRestore();
+		}
+	});
+});

--- a/tests/unit/background/pr-monitor-worker-unref.test.ts
+++ b/tests/unit/background/pr-monitor-worker-unref.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test: PrMonitorWorker's poll timer must not hold the Bun/Node
+ * event loop open.
+ *
+ * Split out of pr-monitor-worker.test.ts (already over the FR-006 500-line
+ * cap — the ratchet in scripts/check-test-file-cap.sh blocks growth of that
+ * file) rather than appended there.
+ */
+import { describe, expect, spyOn, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PrMonitorWorker } from '../../../src/background/pr-monitor-worker';
+
+function makeConfig(): Record<string, unknown> {
+	return {
+		enabled: true,
+		// Long interval — this test asserts on the setInterval call itself,
+		// never lets the poll callback fire.
+		poll_interval_seconds: 100_000,
+		max_subscriptions: 20,
+		max_prs_per_cycle: 5,
+		max_concurrent_pr_polls: 3,
+		poll_timeout_ms: 30_000,
+		failure_threshold: 5,
+		cooldown_seconds: 30,
+		max_cooldown_seconds: 300,
+		cleanup_ttl_days: 7,
+		auto_unsubscribe_on_merge: true,
+		auto_unsubscribe_on_close: true,
+		notify_ci_failure: true,
+		notify_new_comments: true,
+		notify_merge_conflict: true,
+	};
+}
+
+describe('PrMonitorWorker poll timer — regression: unref (issue: event-loop leak)', () => {
+	test('start() calls unref() on the interval timer so it cannot pin the event loop open', () => {
+		// Previous code did `this.pollTimer = setInterval(...)` and never called
+		// `.unref()` on the returned timer. A live, ref'd interval keeps the
+		// Node/Bun event loop from draining naturally, so `process.on('exit', ...)`
+		// cleanup never fires under normal (non-process.exit) shutdown — self-
+		// defeating even though `cleanupAutomation` already calls
+		// `prMonitorWorker?.stop()`.
+		// Clock-free unique name. A wall-clock timestamp would be a uniqueness
+		// source here, not a time-dependent assertion, so wrapping it in
+		// `freezeClock` would be wrong — a frozen clock makes "unique" names
+		// collide. `randomUUID` gives uniqueness without reading the clock at all,
+		// which also keeps scripts/check-test-clock.sh satisfied.
+		const directory = path.join(
+			os.tmpdir(),
+			`pr-monitor-unref-${randomUUID()}`,
+		);
+		const worker = new PrMonitorWorker({
+			directory,
+			config: makeConfig() as ConstructorParameters<
+				typeof PrMonitorWorker
+			>[0]['config'],
+		});
+
+		const realSetInterval = globalThis.setInterval;
+		let capturedTimer: { unref?: () => unknown } | undefined;
+		let unrefCallCount = 0;
+		const setIntervalSpy = spyOn(globalThis, 'setInterval').mockImplementation(
+			((fn: (...args: unknown[]) => void, ms?: number, ...args: unknown[]) => {
+				const timer = realSetInterval(fn, ms, ...args) as unknown as {
+					unref?: () => unknown;
+				};
+				const originalUnref = timer.unref?.bind(timer);
+				timer.unref = (...unrefArgs: unknown[]) => {
+					unrefCallCount++;
+					return originalUnref?.(...unrefArgs);
+				};
+				capturedTimer = timer;
+				return timer;
+			}) as typeof globalThis.setInterval,
+		);
+
+		try {
+			worker.start();
+
+			expect(capturedTimer).toBeDefined();
+			expect(unrefCallCount).toBe(1);
+		} finally {
+			worker.stop();
+			setIntervalSpy.mockRestore();
+		}
+	});
+});

--- a/tests/unit/config/cache-paths.test.ts
+++ b/tests/unit/config/cache-paths.test.ts
@@ -12,6 +12,7 @@ import * as path from 'node:path';
 import {
 	getHostConfigDir,
 	getHostDataDir,
+	getHostSkillCacheDir,
 	getPluginCachePaths,
 	getPluginConfigDir,
 	getPluginLockFilePaths,
@@ -372,5 +373,61 @@ describe('getHostDataDir — precedence (worktree-lane allowlist only)', () => {
 	test('the data dir is NOT the config dir (they are independently derived)', () => {
 		delete process.env.XDG_DATA_HOME;
 		expect(getHostDataDir()).not.toBe(getHostConfigDir());
+	});
+});
+
+describe('getHostSkillCacheDir — URL-skill cache root', () => {
+	const saved = { XDG_CACHE_HOME: process.env.XDG_CACHE_HOME };
+
+	afterEach(() => {
+		for (const [k, v] of Object.entries(saved)) {
+			if (v === undefined) delete process.env[k];
+			else process.env[k] = v;
+		}
+	});
+
+	// Expected values are built from LITERAL joins, never by calling the
+	// function on both sides — the mistake that let a missing XDG branch survive
+	// a mutation run for getHostDataDir.
+
+	test('XDG_CACHE_HOME wins when set', () => {
+		// Verbatim host source (opencode 1.18.10, offset 107378747):
+		//   p = XDG_CACHE_HOME || join(homedir(), '.cache')
+		//   i = join(p, 'opencode')          -> Global.Path.cache
+		// and the skill cache root is join(cache, 'skills') (offset 102988349).
+		const xdg = path.join(os.tmpdir(), 'custom-xdg-cache');
+		process.env.XDG_CACHE_HOME = xdg;
+		expect(getHostSkillCacheDir()).toBe(path.join(xdg, 'opencode', 'skills'));
+	});
+
+	test('falls back to ~/.cache/opencode/skills when unset', () => {
+		delete process.env.XDG_CACHE_HOME;
+		expect(getHostSkillCacheDir()).toBe(
+			path.join(os.homedir(), '.cache', 'opencode', 'skills'),
+		);
+	});
+
+	test('an empty XDG_CACHE_HOME falls back (empty string is falsy, as in the host)', () => {
+		process.env.XDG_CACHE_HOME = '';
+		expect(getHostSkillCacheDir()).toBe(
+			path.join(os.homedir(), '.cache', 'opencode', 'skills'),
+		);
+	});
+
+	test('it is a strict SUBdirectory of the cache root, never the root itself', () => {
+		// Global.Path.bin = join(cache,'bin') is host-executed, so the parent must
+		// never be what this returns.
+		delete process.env.XDG_CACHE_HOME;
+		const skills = getHostSkillCacheDir();
+		const parent = path.dirname(skills);
+		expect(path.basename(skills)).toBe('skills');
+		expect(parent).toBe(path.join(os.homedir(), '.cache', 'opencode'));
+		expect(skills).not.toBe(parent);
+	});
+
+	test('the cache dir is independent of the data and config dirs', () => {
+		delete process.env.XDG_CACHE_HOME;
+		expect(getHostSkillCacheDir()).not.toBe(getHostDataDir());
+		expect(getHostSkillCacheDir()).not.toBe(getHostConfigDir());
 	});
 });

--- a/tests/unit/config/cache-paths.test.ts
+++ b/tests/unit/config/cache-paths.test.ts
@@ -10,7 +10,10 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+	getHostConfigDir,
+	getHostDataDir,
 	getPluginCachePaths,
+	getPluginConfigDir,
 	getPluginLockFilePaths,
 } from '../../../src/config/cache-paths.js';
 
@@ -256,5 +259,118 @@ describe('getPluginLockFilePaths', () => {
 		expect(
 			paths.some((p) => p === path.join(fallbackLocal, 'opencode', 'bun.lock')),
 		).toBe(true);
+	});
+});
+
+describe('getHostConfigDir — precedence (worktree-lane allowlist only)', () => {
+	const saved = {
+		OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
+		XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+	};
+
+	afterEach(() => {
+		for (const [k, v] of Object.entries(saved)) {
+			if (v === undefined) delete process.env[k];
+			else process.env[k] = v;
+		}
+	});
+
+	test('OPENCODE_CONFIG_DIR wins when set', () => {
+		// Verbatim host precedence (opencode 1.18.10, offset 107379448):
+		//   config: e.OPENCODE_CONFIG_DIR ?? G.config
+		process.env.OPENCODE_CONFIG_DIR = path.join(
+			os.tmpdir(),
+			'custom-oc-config',
+		);
+		expect(getHostConfigDir()).toBe(path.join(os.tmpdir(), 'custom-oc-config'));
+	});
+
+	test('falls back to the XDG/plugin config dir when unset', () => {
+		delete process.env.OPENCODE_CONFIG_DIR;
+		expect(getHostConfigDir()).toBe(getPluginConfigDir());
+	});
+
+	test('an empty or whitespace OPENCODE_CONFIG_DIR is ignored', () => {
+		for (const bogus of ['', '   ']) {
+			process.env.OPENCODE_CONFIG_DIR = bogus;
+			expect(getHostConfigDir()).toBe(getPluginConfigDir());
+		}
+	});
+
+	test('getPluginConfigDir keeps its shared semantics (ignores the env var)', () => {
+		// src/cli/index.ts and src/services/diagnose-service.ts depend on this
+		// function meaning "the XDG plugin config dir"; only the lane allowlist
+		// wants the host override.
+		process.env.OPENCODE_CONFIG_DIR = path.join(os.tmpdir(), 'other-config');
+		expect(getPluginConfigDir()).not.toBe(process.env.OPENCODE_CONFIG_DIR);
+	});
+});
+
+describe('getHostDataDir — precedence (worktree-lane allowlist only)', () => {
+	const saved = {
+		XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+	};
+
+	afterEach(() => {
+		for (const [k, v] of Object.entries(saved)) {
+			if (v === undefined) delete process.env[k];
+			else process.env[k] = v;
+		}
+	});
+
+	// Every assertion below builds the expected value from a LITERAL join rather
+	// than by calling getHostDataDir() again. Calling the function on both sides
+	// passes for any implementation, including a wrong one — which is how the
+	// missing XDG_DATA_HOME branch survived a mutation run.
+
+	test('XDG_DATA_HOME wins when set', () => {
+		// Verbatim host source (opencode 1.18.10, offset ~107378334):
+		//   V = R.XDG_DATA_HOME || (X ? Z.join(X, ".local", "share") : undefined)
+		//   An.data = H.join(V, "opencode")
+		const xdg = path.join(os.tmpdir(), 'custom-xdg-data');
+		process.env.XDG_DATA_HOME = xdg;
+		expect(getHostDataDir()).toBe(path.join(xdg, 'opencode'));
+	});
+
+	test('falls back to ~/.local/share/opencode when unset', () => {
+		delete process.env.XDG_DATA_HOME;
+		expect(getHostDataDir()).toBe(
+			path.join(os.homedir(), '.local', 'share', 'opencode'),
+		);
+	});
+
+	test('an empty XDG_DATA_HOME falls back (empty string is falsy, as in the host)', () => {
+		process.env.XDG_DATA_HOME = '';
+		expect(getHostDataDir()).toBe(
+			path.join(os.homedir(), '.local', 'share', 'opencode'),
+		);
+	});
+
+	test('a whitespace XDG_DATA_HOME is honoured verbatim (host uses ||, not trim)', () => {
+		// Deliberately asserting the host's actual semantics rather than a nicer
+		// one: `||` treats "   " as truthy, so the host would use it too. If we
+		// diverged here our rule text would stop matching the host's asked text.
+		process.env.XDG_DATA_HOME = '   ';
+		expect(getHostDataDir()).toBe(path.join('   ', 'opencode'));
+	});
+
+	test('there is no OPENCODE_DATA_DIR override (unlike the config dir)', () => {
+		delete process.env.XDG_DATA_HOME;
+		(process.env as Record<string, string>).OPENCODE_DATA_DIR = path.join(
+			os.tmpdir(),
+			'should-be-ignored',
+		);
+		try {
+			expect(getHostDataDir()).toBe(
+				path.join(os.homedir(), '.local', 'share', 'opencode'),
+			);
+		} finally {
+			delete (process.env as Record<string, string>).OPENCODE_DATA_DIR;
+		}
+	});
+
+	test('the data dir is NOT the config dir (they are independently derived)', () => {
+		delete process.env.XDG_DATA_HOME;
+		expect(getHostDataDir()).not.toBe(getHostConfigDir());
 	});
 });

--- a/tests/unit/config/host-path.test.ts
+++ b/tests/unit/config/host-path.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Transcription of OpenCode's `Filesystem.normalizePathPattern`.
+ *
+ * Lane rule patterns must be byte-identical to what the host produces for the
+ * asked path, because `Permission.fromConfig` applies no canonicalisation of
+ * its own. If this transcription drifts from the host, every lane grant stops
+ * matching and the lane is denied access to its own directories.
+ *
+ * The convergence property (a symlink/junction path and its real path produce
+ * the SAME pattern) is what makes the grant work; it is asserted here against a
+ * real on-disk link rather than a mock.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	_internals,
+	_test_exports,
+	hostNormalizePathPattern,
+} from '../../../src/config/host-path';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const { hostWindowsPath, hostNormalizePath } = _test_exports;
+const realRealpath = _internals.realpathSyncNative;
+
+afterEach(() => {
+	_internals.realpathSyncNative = realRealpath;
+});
+
+describe('hostWindowsPath — verbatim drive-letter rewrites', () => {
+	test.each([
+		['/c:/Users/x', 'C:/Users/x'],
+		['/c/Users/x', 'C:/Users/x'],
+		['/cygdrive/d/work', 'D:/work'],
+		['/mnt/e/repo', 'E:/repo'],
+	])('%s -> %s', (input, expected) => {
+		expect(hostWindowsPath(input)).toBe(expected);
+	});
+
+	test.each([
+		['C:\\already\\windows'],
+		['/usr/local/share'],
+		['/home/user/project'],
+		['relative/path'],
+	])('%s is left alone', (input) => {
+		expect(hostWindowsPath(input)).toBe(input);
+	});
+});
+
+describe('hostNormalizePathPattern — host contract', () => {
+	test('the bare catch-all is returned untouched', () => {
+		// The host special-cases this before any path handling.
+		expect(hostNormalizePathPattern('*')).toBe('*');
+	});
+
+	// WINDOWS ONLY. `C:` is a drive root only under win32 path semantics; under
+	// POSIX `path.resolve('C:\\')` prepends the cwd, so an unconditional
+	// assertion here passes on a Windows dev box and fails on the ubuntu CI
+	// runner. Same class as the `swwt` assertion in lane-permissions.test.ts.
+	test.skipIf(process.platform !== 'win32')(
+		'a drive-root pattern keeps its root (does not become the cwd)',
+		() => {
+			// Host special case: `C:` alone would resolve to the process's current
+			// directory on that drive, so a separator is appended first.
+			expect(hostNormalizePathPattern('C:/*')).toBe(path.join('C:\\', '*'));
+		},
+	);
+
+	test('the drive-root special case never throws, on any platform', () => {
+		// Platform-agnostic half of the case above: whatever the path flavour, the
+		// branch must produce a usable pattern rather than blowing up.
+		expect(() => hostNormalizePathPattern('C:/*')).not.toThrow();
+		expect(hostNormalizePathPattern('C:/*').endsWith('*')).toBe(true);
+	});
+
+	test('a non-existent directory degrades to the resolved form (ENOENT)', () => {
+		const missing = path.resolve('/definitely/not/here/at/all');
+		expect(hostNormalizePathPattern(path.join(missing, '*'))).toBe(
+			path.join(missing, '*'),
+		);
+	});
+
+	test('a non-pattern input falls through to normalizePath', () => {
+		const p = path.resolve('/some/plain/path');
+		expect(hostNormalizePathPattern(p)).toBe(hostNormalizePath(p));
+	});
+
+	test('a realpath failure other than ENOENT still degrades rather than throwing', () => {
+		_internals.realpathSyncNative = () => {
+			const err = new Error('EACCES') as NodeJS.ErrnoException;
+			err.code = 'EACCES';
+			throw err;
+		};
+		const p = path.resolve('/x/y');
+		expect(() => hostNormalizePathPattern(path.join(p, '*'))).not.toThrow();
+		expect(hostNormalizePathPattern(path.join(p, '*'))).toBe(path.join(p, '*'));
+	});
+});
+
+describe('convergence: a linked path and its target produce the same pattern', () => {
+	test('symlink/junction resolves to the real target', () => {
+		const { dir, cleanup } = createSafeTestDir('host-path-');
+		try {
+			const real = path.join(dir, 'real-target');
+			fs.mkdirSync(real, { recursive: true });
+			const link = path.join(dir, 'link-to-target');
+			try {
+				fs.symlinkSync(real, link, 'junction');
+			} catch {
+				// Symlink/junction creation can require elevation on some hosts.
+				return;
+			}
+			const viaLink = hostNormalizePathPattern(path.join(link, '*'));
+			const viaReal = hostNormalizePathPattern(path.join(real, '*'));
+			// THE property: an un-canonicalised rule would name the link and never
+			// match the host's asked pattern, denying the lane its own grant.
+			expect(viaLink).toBe(viaReal);
+			expect(viaLink).toBe(path.join(fs.realpathSync.native(real), '*'));
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/tests/unit/config/host-path.test.ts
+++ b/tests/unit/config/host-path.test.ts
@@ -91,9 +91,77 @@ describe('hostNormalizePathPattern — host contract', () => {
 			err.code = 'EACCES';
 			throw err;
 		};
-		const p = path.resolve('/x/y');
-		expect(() => hostNormalizePathPattern(path.join(p, '*'))).not.toThrow();
-		expect(hostNormalizePathPattern(path.join(p, '*'))).toBe(path.join(p, '*'));
+		// A REAL directory, not a synthetic '/x/y': under POSIX the host's
+		// windowsPath rewrites a single-letter first segment ('/x/y' -> 'X:/y'),
+		// which path.resolve then re-anchors under cwd. See the dedicated
+		// single-letter regression block below.
+		const { dir: realDir, cleanup } = createSafeTestDir('host-path-degrade-');
+		try {
+			const p = path.resolve(realDir);
+			expect(() => hostNormalizePathPattern(path.join(p, '*'))).not.toThrow();
+			expect(hostNormalizePathPattern(path.join(p, '*'))).toBe(
+				path.join(p, '*'),
+			);
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe('regression (PR #2015 CI): single-letter first segment is an MSYS drive', () => {
+	// FOUND BY CI, NOT LOCALLY. On Windows `path.resolve("/a/b")` yields
+	// `C:\a\b`, so this never fired; on ubuntu/macos it does.
+	//
+	// The host's `windowsPath` (binary offset ~107196300) has FOUR rewrites, and
+	// the second one is an MSYS single-letter drive mapping:
+	//
+	//   .replace(/^\/([a-zA-Z])(?:\/|$)/, (z, Z) => `${Z.toUpperCase()}:/`)
+	//
+	// It fires on ANY POSIX path whose first segment is a single letter, so
+	// `/a/b` -> `A:/b`. `path.resolve` then treats `A:/b` as relative under
+	// POSIX and re-anchors it beneath the cwd.
+	//
+	// This is NOT a defect in our transcription — it is the host's own
+	// behaviour, faithfully reproduced. It is also HARMLESS for matching,
+	// because the host applies the identical rewrite to the patterns it ASKS
+	// with (`normalizePathPattern` calls the same `normalizePath`), so a rule
+	// and an ask for the same directory are mangled the same way and still
+	// compare equal. The asserted convergence is pinned below.
+	//
+	// The practical consequence is for TEST FIXTURES: never use a synthetic
+	// absolute path whose first segment is a single letter. Use a real
+	// directory, or at least a multi-letter first segment.
+	const singleLetter = ['/a/b', '/x/y', '/c/Users/x', '/z'];
+	const multiLetter = ['/aa/bb', '/tmp/proj', '/home/runner/x', '/opt/x'];
+
+	test.skipIf(process.platform === 'win32').each(singleLetter)(
+		'%s is rewritten to a drive-letter form under POSIX',
+		(input) => {
+			expect(hostWindowsPath(input)).toMatch(/^[A-Z]:\//);
+		},
+	);
+
+	test.each(multiLetter)('%s is left alone', (input) => {
+		expect(hostWindowsPath(input)).toBe(input);
+	});
+
+	test('a rule and an ask for the same directory still converge', () => {
+		// The property that makes the rewrite harmless in production: both sides
+		// go through the same normaliser, so they agree whatever it does.
+		for (const dir of [...singleLetter, ...multiLetter]) {
+			const rulePattern = hostNormalizePathPattern(path.join(dir, '*'));
+			const askedPattern = hostNormalizePathPattern(path.join(dir, '*'));
+			expect(rulePattern).toBe(askedPattern);
+		}
+	});
+
+	test('the transcription matches the host regex exactly (all four rewrites)', () => {
+		// Guards against someone "fixing" the single-letter rule out of
+		// hostWindowsPath after reading the CI failure above.
+		expect(hostWindowsPath('/c:/Users/x')).toBe('C:/Users/x');
+		expect(hostWindowsPath('/c/Users/x')).toBe('C:/Users/x');
+		expect(hostWindowsPath('/cygdrive/d/work')).toBe('D:/work');
+		expect(hostWindowsPath('/mnt/e/repo')).toBe('E:/repo');
 	});
 });
 

--- a/tests/unit/config/lane-context-layouts.test.ts
+++ b/tests/unit/config/lane-context-layouts.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Lane detection across the three worktree PROVISIONING LAYOUTS, and the
+ * user-authored branches that must never be captured.
+ *
+ * Split out of `lane-context.test.ts` to stay under the FR-006 500-line cap.
+ * Shares the on-disk fixture style of that file: real `.git` files pointing at
+ * real `<main>/.git/worktrees/<name>` administrative directories, because the
+ * whole point of `resolveLaneContext` is that it reads exactly what git writes.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { SWARM_WORKTREE_DIR_NAME } from '../../../src/config/constants';
+import {
+	_internals,
+	resolveLaneContext,
+} from '../../../src/config/lane-context';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const realAddDeferredWarning = _internals.addDeferredWarning;
+
+let root: string;
+let cleanup: () => void;
+
+/**
+ * Materialises `<root>/<project>` as a main working tree and
+ * `<root>/.swarm-worktrees/<session>/<lane>` as a linked worktree of it,
+ * mirroring what `provisionWorktree` produces.
+ */
+function makeLane(opts?: {
+	withCommondir?: boolean;
+	gitdirOverride?: string;
+	laneDotGitIsDirectory?: boolean;
+}): { lanePath: string; projectPath: string } {
+	const projectPath = path.join(root, 'my-project');
+	const lanePath = path.join(
+		root,
+		SWARM_WORKTREE_DIR_NAME,
+		'ses_abc123',
+		'1.1',
+	);
+	const adminDir = path.join(projectPath, '.git', 'worktrees', '1.1');
+	fs.mkdirSync(adminDir, { recursive: true });
+	fs.mkdirSync(lanePath, { recursive: true });
+
+	if (opts?.laneDotGitIsDirectory) {
+		fs.mkdirSync(path.join(lanePath, '.git'), { recursive: true });
+	} else {
+		// git writes forward slashes here even on Windows.
+		const pointer = opts?.gitdirOverride ?? adminDir.split(path.sep).join('/');
+		fs.writeFileSync(
+			path.join(lanePath, '.git'),
+			`gitdir: ${pointer}\n`,
+			'utf-8',
+		);
+	}
+	if (opts?.withCommondir !== false) {
+		fs.writeFileSync(path.join(adminDir, 'commondir'), '../..\n', 'utf-8');
+	}
+	return { lanePath, projectPath };
+}
+
+beforeEach(() => {
+	({ dir: root, cleanup } = createSafeTestDir('swarm-lane-ctx-'));
+	_internals.clearCache();
+});
+
+afterEach(() => {
+	_internals.clearCache();
+	_internals.readFileSync = fs.readFileSync as typeof _internals.readFileSync;
+	_internals.statSync = fs.statSync as unknown as typeof _internals.statSync;
+	_internals.addDeferredWarning = realAddDeferredWarning;
+	cleanup();
+});
+
+describe('resolveLaneContext — regression (HIGH-1): all three provisioning layouts', () => {
+	// provisionWorktree can place a lane in three different locations, and only
+	// the first contains `.swarm-worktrees`. Keying detection on the path alone
+	// silently missed the other two — including the Windows fallback, which
+	// fires with NO user configuration and is the platform this defect was
+	// reported on. Branch name is the path-independent marker.
+
+	/** Builds a linked worktree at an arbitrary path on the given branch. */
+	function makeWorktreeAt(
+		lanePath: string,
+		branch: string,
+	): { lanePath: string; projectPath: string } {
+		const projectPath = path.join(root, 'proj-layouts');
+		const adminDir = path.join(
+			projectPath,
+			'.git',
+			'worktrees',
+			path.basename(lanePath),
+		);
+		fs.mkdirSync(adminDir, { recursive: true });
+		fs.mkdirSync(lanePath, { recursive: true });
+		fs.writeFileSync(path.join(adminDir, 'commondir'), '../..\n', 'utf-8');
+		fs.writeFileSync(
+			path.join(adminDir, 'HEAD'),
+			`ref: refs/heads/${branch}\n`,
+			'utf-8',
+		);
+		fs.writeFileSync(
+			path.join(lanePath, '.git'),
+			`gitdir: ${adminDir.split(path.sep).join('/')}\n`,
+			'utf-8',
+		);
+		return { lanePath, projectPath };
+	}
+
+	test('layout 2: a worktree_dir override lane (no .swarm-worktrees segment) is detected', () => {
+		// resolveWorktreeBaseDir(directory, worktreeDir) resolves to an arbitrary
+		// configured path.
+		const { lanePath, projectPath } = makeWorktreeAt(
+			path.join(root, 'custom-wt', 'ses_x', '2.1'),
+			'swarm/lane/ses_x/2.1',
+		);
+		expect(lanePath).not.toContain(SWARM_WORKTREE_DIR_NAME);
+		expect(resolveLaneContext(lanePath)?.parentProjectPath).toBe(
+			path.resolve(projectPath),
+		);
+	});
+
+	test('layout 3: the Windows path-budget fallback (<tmp>/swwt/...) is detected', () => {
+		// shortenWorktreePath() returns path.join(os.tmpdir(), 'swwt', ses, lane).
+		const { lanePath, projectPath } = makeWorktreeAt(
+			path.join(root, 'swwt', 'ses_y', '3.1'),
+			'swarm/lane/ses_y/3.1',
+		);
+		expect(lanePath).not.toContain(SWARM_WORKTREE_DIR_NAME);
+		expect(resolveLaneContext(lanePath)?.parentProjectPath).toBe(
+			path.resolve(projectPath),
+		);
+	});
+
+	test("the legacy-lane branch style ('swarm-lane/...') is also recognised", () => {
+		const { lanePath } = makeWorktreeAt(
+			path.join(root, 'legacy-wt', '4.1'),
+			'swarm-lane/ses_z/4.1',
+		);
+		expect(resolveLaneContext(lanePath)).not.toBeNull();
+	});
+
+	test('a linked worktree on a NON-swarm branch outside the base is still ignored', () => {
+		const { lanePath } = makeWorktreeAt(
+			path.join(root, 'user-wt', 'feature'),
+			'feature/my-work',
+		);
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+
+	test('a decoy branch that merely contains "swarm/" mid-name is ignored', () => {
+		const { lanePath } = makeWorktreeAt(
+			path.join(root, 'decoy-wt', 'x'),
+			'feature/not-swarm/thing',
+		);
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+
+	test('regression (HIGH-1 r3): a user worktree INSIDE .swarm-worktrees is NOT a lane', () => {
+		// Reproduced with real git:
+		//   git worktree add -b my-feature ../.swarm-worktrees/manual-user-wt
+		// The old path fallback matched "any path containing a .swarm-worktrees
+		// segment", so this ordinary interactive session was classified as a lane
+		// and had an unrecoverable deny-by-default injected. The path signal now
+		// requires the FULL provisioned shape
+		// `<base>/.swarm-worktrees/<ses_...>/<id>`.
+		const { lanePath } = makeWorktreeAt(
+			path.join(root, SWARM_WORKTREE_DIR_NAME, 'manual-user-wt'),
+			'my-feature',
+		);
+		expect(lanePath).toContain(SWARM_WORKTREE_DIR_NAME);
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+
+	test.each([
+		// A non-swarm branch at the right DEPTH but a bad session segment.
+		['notasession', '1.1'],
+		['SES_abc', '1.1'],
+		['ses-abc', '1.1'],
+	])('regression (HIGH-1 r3): .swarm-worktrees/%s/%s is NOT a lane', (sessionSeg, id) => {
+		const { lanePath } = makeWorktreeAt(
+			path.join(root, SWARM_WORKTREE_DIR_NAME, sessionSeg, id),
+			'my-feature',
+		);
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+
+	test('a DETACHED-HEAD lane at the full provisioned shape still resolves', () => {
+		// The path fallback must survive the narrowing — it is the only signal
+		// for a lane whose HEAD carries a bare SHA.
+		const { lanePath, projectPath } = makeWorktreeAt(
+			path.join(root, SWARM_WORKTREE_DIR_NAME, 'ses_abc123', '1.1'),
+			'swarm/lane/ses_abc123/1.1',
+		);
+		const adminDir = path.join(
+			root,
+			'proj-layouts',
+			'.git',
+			'worktrees',
+			'1.1',
+		);
+		fs.writeFileSync(
+			path.join(adminDir, 'HEAD'),
+			'0123456789abcdef0123456789abcdef01234567\n',
+			'utf-8',
+		);
+		_internals.clearCache();
+		expect(resolveLaneContext(lanePath)?.parentProjectPath).toBe(
+			path.resolve(projectPath),
+		);
+	});
+
+	test.each([
+		// Reproduced HIGH-1: `git worktree add -b swarm/my-own-experiment ../scratch`
+		['swarm/my-own-experiment'],
+		['swarm/feature/foo'],
+		['swarm-lane/wip'],
+		['swarm/lane/notasession/1.1'],
+		['swarm/lane/ses_x/1.1-extra-segment/deep'],
+	])('regression (HIGH-1): user branch %s outside the swarm base is NOT a lane', (branch) => {
+		// A bare `swarm/` prefix used to be sufficient. Misclassifying an
+		// ordinary session injects a deny-all it cannot recover from, because
+		// the host's Permission.ask short-circuits on deny before creating any
+		// deferred — no prompt, so "Allow always" is unreachable.
+		const safeName = branch.replace(/[^A-Za-z0-9]/g, '_');
+		const { lanePath } = makeWorktreeAt(
+			path.join(root, 'user-branches', safeName),
+			branch,
+		);
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+
+	test('detached HEAD inside the swarm base still falls back to the path signal', () => {
+		const { lanePath } = makeWorktreeAt(
+			path.join(root, SWARM_WORKTREE_DIR_NAME, 'ses_d', '5.1'),
+			'swarm/lane/ses_d/5.1',
+		);
+		// Overwrite HEAD with a bare SHA (detached).
+		const adminDir = path.join(
+			root,
+			'proj-layouts',
+			'.git',
+			'worktrees',
+			'5.1',
+		);
+		fs.writeFileSync(
+			path.join(adminDir, 'HEAD'),
+			'0123456789abcdef0123456789abcdef01234567\n',
+			'utf-8',
+		);
+		_internals.clearCache();
+		expect(resolveLaneContext(lanePath)).not.toBeNull();
+	});
+
+	test('layout D: an instance dir NESTED below a lane resolves to the lane root', () => {
+		// A nested directory has no `.git` of its own — git never writes one —
+		// so a same-directory-only check returns "not a lane" and the nested
+		// instance keeps hanging. The bounded ancestor walk finds the lane root.
+		//
+		// NOTE the previous version of this test wrote a `.git` file into the
+		// nested directory before asserting. That fabricated the very property
+		// under test and is exactly why this gap stayed invisible.
+		const { lanePath, projectPath } = makeWorktreeAt(
+			path.join(root, SWARM_WORKTREE_DIR_NAME, 'ses_n', '6.1'),
+			'swarm/lane/ses_n/6.1',
+		);
+		const nested = path.join(lanePath, 'a', 'b', 'c');
+		fs.mkdirSync(nested, { recursive: true });
+		expect(fs.existsSync(path.join(nested, '.git'))).toBe(false);
+
+		const result = resolveLaneContext(nested);
+		expect(result).not.toBeNull();
+		// lanePath is the LANE ROOT, not the queried nested directory.
+		expect(result?.lanePath).toBe(path.resolve(lanePath));
+		expect(result?.parentProjectPath).toBe(path.resolve(projectPath));
+	});
+
+	test('the ancestor walk stops at the filesystem root without throwing', () => {
+		const orphan = path.join(root, 'no-git-anywhere', 'deep', 'deeper');
+		fs.mkdirSync(orphan, { recursive: true });
+		expect(() => resolveLaneContext(orphan)).not.toThrow();
+		expect(resolveLaneContext(orphan)).toBeNull();
+	});
+});

--- a/tests/unit/config/lane-context.test.ts
+++ b/tests/unit/config/lane-context.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Swarm worktree-lane detection.
+ *
+ * These tests build REAL on-disk fixtures (a `.git` file pointing at a
+ * `<main>/.git/worktrees/<name>` administrative directory) rather than mocking
+ * the filesystem, because the whole point of `resolveLaneContext` is that it
+ * reads exactly the files git itself writes. A mocked `readFileSync` would
+ * prove only that the parser works, not that the layout assumption is right.
+ * The layout was verified against a live lane on this machine:
+ *
+ *   E:/OpenCode/.swarm-worktrees/ses_.../1.1/.git
+ *     -> "gitdir: E:/OpenCode/opencode-swarm-dev2/.git/worktrees/1.1"
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { SWARM_WORKTREE_DIR_NAME } from '../../../src/config/constants';
+import {
+	_internals,
+	resolveLaneContext,
+} from '../../../src/config/lane-context';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+const realAddDeferredWarning = _internals.addDeferredWarning;
+
+let root: string;
+let cleanup: () => void;
+
+/**
+ * Materialises `<root>/<project>` as a main working tree and
+ * `<root>/.swarm-worktrees/<session>/<lane>` as a linked worktree of it,
+ * mirroring what `provisionWorktree` produces.
+ */
+function makeLane(opts?: {
+	withCommondir?: boolean;
+	gitdirOverride?: string;
+	laneDotGitIsDirectory?: boolean;
+}): { lanePath: string; projectPath: string } {
+	const projectPath = path.join(root, 'my-project');
+	const lanePath = path.join(
+		root,
+		SWARM_WORKTREE_DIR_NAME,
+		'ses_abc123',
+		'1.1',
+	);
+	const adminDir = path.join(projectPath, '.git', 'worktrees', '1.1');
+	fs.mkdirSync(adminDir, { recursive: true });
+	fs.mkdirSync(lanePath, { recursive: true });
+
+	if (opts?.laneDotGitIsDirectory) {
+		fs.mkdirSync(path.join(lanePath, '.git'), { recursive: true });
+	} else {
+		// git writes forward slashes here even on Windows.
+		const pointer = opts?.gitdirOverride ?? adminDir.split(path.sep).join('/');
+		fs.writeFileSync(
+			path.join(lanePath, '.git'),
+			`gitdir: ${pointer}\n`,
+			'utf-8',
+		);
+	}
+	if (opts?.withCommondir !== false) {
+		fs.writeFileSync(path.join(adminDir, 'commondir'), '../..\n', 'utf-8');
+	}
+	return { lanePath, projectPath };
+}
+
+beforeEach(() => {
+	({ dir: root, cleanup } = createSafeTestDir('swarm-lane-ctx-'));
+	_internals.clearCache();
+});
+
+afterEach(() => {
+	_internals.clearCache();
+	_internals.readFileSync = fs.readFileSync as typeof _internals.readFileSync;
+	_internals.statSync = fs.statSync as unknown as typeof _internals.statSync;
+	_internals.addDeferredWarning = realAddDeferredWarning;
+	cleanup();
+});
+
+describe('resolveLaneContext — positive detection', () => {
+	test('recognises a lane and resolves the parent project via commondir', () => {
+		const { lanePath, projectPath } = makeLane();
+		const result = resolveLaneContext(lanePath);
+		expect(result).not.toBeNull();
+		expect(result?.lanePath).toBe(path.resolve(lanePath));
+		expect(result?.parentProjectPath).toBe(path.resolve(projectPath));
+	});
+
+	test('falls back to the documented .git/worktrees layout when commondir is absent', () => {
+		const { lanePath, projectPath } = makeLane({ withCommondir: false });
+		const result = resolveLaneContext(lanePath);
+		expect(result?.parentProjectPath).toBe(path.resolve(projectPath));
+	});
+
+	test('accepts a relative gitdir pointer (git writes these for nested layouts)', () => {
+		const { lanePath, projectPath } = makeLane();
+		const adminDir = path.join(projectPath, '.git', 'worktrees', '1.1');
+		const relative = path
+			.relative(lanePath, adminDir)
+			.split(path.sep)
+			.join('/');
+		fs.writeFileSync(
+			path.join(lanePath, '.git'),
+			`gitdir: ${relative}\n`,
+			'utf-8',
+		);
+		_internals.clearCache();
+		expect(resolveLaneContext(lanePath)?.parentProjectPath).toBe(
+			path.resolve(projectPath),
+		);
+	});
+});
+
+describe('resolveLaneContext — negative detection (ordinary sessions unaffected)', () => {
+	test('a plain project directory is not a lane', () => {
+		const project = path.join(root, 'plain');
+		fs.mkdirSync(path.join(project, '.git'), { recursive: true });
+		expect(resolveLaneContext(project)).toBeNull();
+	});
+
+	test('a directory under .swarm-worktrees that is NOT a linked worktree is not a lane', () => {
+		// Both signals are required; the marker alone must not be enough.
+		const stray = path.join(root, SWARM_WORKTREE_DIR_NAME, 'ses_x', 'stray');
+		fs.mkdirSync(stray, { recursive: true });
+		expect(resolveLaneContext(stray)).toBeNull();
+	});
+
+	test('a real linked worktree OUTSIDE the swarm base is left alone', () => {
+		// A user-created `git worktree add` must not inherit lane policy.
+		const projectPath = path.join(root, 'proj2');
+		const userWorktree = path.join(root, 'user-worktree');
+		const adminDir = path.join(projectPath, '.git', 'worktrees', 'wt');
+		fs.mkdirSync(adminDir, { recursive: true });
+		fs.mkdirSync(userWorktree, { recursive: true });
+		fs.writeFileSync(path.join(adminDir, 'commondir'), '../..\n', 'utf-8');
+		fs.writeFileSync(
+			path.join(userWorktree, '.git'),
+			`gitdir: ${adminDir.split(path.sep).join('/')}\n`,
+			'utf-8',
+		);
+		expect(resolveLaneContext(userWorktree)).toBeNull();
+	});
+
+	test('a segment that merely CONTAINS the marker does not match', () => {
+		const decoy = path.join(root, `${SWARM_WORKTREE_DIR_NAME}-backup`, 'x');
+		fs.mkdirSync(decoy, { recursive: true });
+		expect(resolveLaneContext(decoy)).toBeNull();
+	});
+
+	test('lane .git being a directory (a main tree) is not a lane', () => {
+		const { lanePath } = makeLane({ laneDotGitIsDirectory: true });
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+});
+
+describe('resolveLaneContext — never throws', () => {
+	test('non-existent directory returns null', () => {
+		expect(
+			resolveLaneContext(
+				path.join(root, SWARM_WORKTREE_DIR_NAME, 'ses', 'nope'),
+			),
+		).toBeNull();
+	});
+
+	test.each([
+		['empty string', ''],
+		['whitespace only', '   '],
+		['traversal-flavoured relative path', '../../../etc'],
+		['traversal under the marker', `${SWARM_WORKTREE_DIR_NAME}/../../etc`],
+		['nul byte', 'lane\u0000/.swarm-worktrees'],
+	])('%s returns null without throwing', (_label, input) => {
+		expect(() => resolveLaneContext(input)).not.toThrow();
+		expect(resolveLaneContext(input)).toBeNull();
+	});
+
+	test.each([
+		['not a string', 42],
+		['null', null],
+		['undefined', undefined],
+	])('%s returns null without throwing', (_label, input) => {
+		expect(() => resolveLaneContext(input as unknown as string)).not.toThrow();
+		expect(resolveLaneContext(input as unknown as string)).toBeNull();
+	});
+
+	test('an unreadable .git (permission error) degrades to null, not a throw', () => {
+		const { lanePath } = makeLane();
+		_internals.readFileSync = (() => {
+			const err = new Error(
+				'EACCES: permission denied',
+			) as NodeJS.ErrnoException;
+			err.code = 'EACCES';
+			throw err;
+		}) as typeof _internals.readFileSync;
+		_internals.clearCache();
+		expect(() => resolveLaneContext(lanePath)).not.toThrow();
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+
+	test('a statSync throw degrades to null', () => {
+		const { lanePath } = makeLane();
+		_internals.statSync = (() => {
+			throw new Error('boom');
+		}) as unknown as typeof _internals.statSync;
+		_internals.clearCache();
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+});
+
+describe('resolveLaneContext — malformed git metadata', () => {
+	test('a .git file with no gitdir line returns null', () => {
+		const { lanePath } = makeLane();
+		fs.writeFileSync(path.join(lanePath, '.git'), 'garbage\n', 'utf-8');
+		_internals.clearCache();
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+
+	test('a gitdir pointing somewhere that is not .git/worktrees/<n> returns null', () => {
+		const bogus = path.join(root, 'elsewhere');
+		fs.mkdirSync(bogus, { recursive: true });
+		const { lanePath } = makeLane({
+			withCommondir: false,
+			gitdirOverride: bogus.split(path.sep).join('/'),
+		});
+		_internals.clearCache();
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+
+	test('a lane whose parent resolves to itself returns null', () => {
+		const { lanePath } = makeLane({ withCommondir: false });
+		// commondir that points back at the lane itself.
+		const adminDir = path.join(root, 'my-project', '.git', 'worktrees', '1.1');
+		fs.writeFileSync(
+			path.join(adminDir, 'commondir'),
+			path.join(lanePath, '.git').split(path.sep).join('/'),
+			'utf-8',
+		);
+		_internals.clearCache();
+		expect(resolveLaneContext(lanePath)).toBeNull();
+	});
+});
+
+describe('resolveLaneContext — caching', () => {
+	test('a second call does not re-read the filesystem', () => {
+		const { lanePath } = makeLane();
+		const first = resolveLaneContext(lanePath);
+		let reads = 0;
+		_internals.readFileSync = ((p: string, enc: BufferEncoding) => {
+			reads += 1;
+			return fs.readFileSync(p, enc);
+		}) as typeof _internals.readFileSync;
+		const second = resolveLaneContext(lanePath);
+		expect(reads).toBe(0);
+		expect(second).toEqual(first);
+	});
+
+	test('negative results are cached too', () => {
+		// Must be a directory that actually reaches the git probe. A fixture that
+		// short-circuits earlier would make the "0 further stats" assertion pass
+		// vacuously.
+		const plain = path.join(
+			root,
+			SWARM_WORKTREE_DIR_NAME,
+			'ses_cache',
+			'not-a-worktree',
+		);
+		fs.mkdirSync(plain, { recursive: true });
+		let stats = 0;
+		const counting = ((p: string) => {
+			stats += 1;
+			return fs.statSync(p);
+		}) as unknown as typeof _internals.statSync;
+
+		_internals.statSync = counting;
+		expect(resolveLaneContext(plain)).toBeNull();
+		// Sanity: the fixture really did exercise the filesystem probe (the
+		// ancestor walk stats `.git` at each level), so the assertion below is
+		// meaningful.
+		expect(stats).toBeGreaterThan(0);
+
+		stats = 0;
+		expect(resolveLaneContext(plain)).toBeNull();
+		expect(stats).toBe(0);
+	});
+
+	test('the cache is bounded and evicts FIFO (AGENTS.md invariant 8)', () => {
+		// 256 is MAX_CACHED_DIRECTORIES. Insert one more than the cap and assert
+		// the oldest key was evicted (it must be probed again) while a recent key
+		// is still served from cache.
+		const first = path.join(root, 'cache-0');
+		fs.mkdirSync(first, { recursive: true });
+		expect(resolveLaneContext(first)).toBeNull();
+		for (let i = 1; i <= 256; i += 1) {
+			resolveLaneContext(path.join(root, `cache-${i}`));
+		}
+
+		let stats = 0;
+		_internals.statSync = ((p: string) => {
+			stats += 1;
+			return fs.statSync(p);
+		}) as unknown as typeof _internals.statSync;
+
+		// Oldest entry was evicted -> probed again.
+		resolveLaneContext(first);
+		expect(stats).toBeGreaterThan(0);
+
+		// A recently inserted entry is still cached -> no probe.
+		stats = 0;
+		resolveLaneContext(path.join(root, 'cache-256'));
+		expect(stats).toBe(0);
+	});
+
+	test('regression (MEDIUM-7): a transient I/O failure is NOT cached as "not a lane"', () => {
+		// Caching an EACCES/EMFILE as a negative would silently disable lane
+		// permission scoping for that directory for the whole process lifetime,
+		// reinstating the hang with no way to recover short of a restart.
+		const { lanePath, projectPath } = makeLane();
+		const warnings: string[] = [];
+		_internals.addDeferredWarning = (w: string) => {
+			warnings.push(w);
+		};
+		_internals.statSync = (() => {
+			const err = new Error(
+				'EMFILE: too many open files',
+			) as NodeJS.ErrnoException;
+			err.code = 'EMFILE';
+			throw err;
+		}) as unknown as typeof _internals.statSync;
+
+		expect(resolveLaneContext(lanePath)).toBeNull();
+		// Surfaced, not silent.
+		expect(warnings.length).toBe(1);
+		expect(warnings[0]).toContain(lanePath);
+
+		// Recovery: the very next call, with I/O working again, must succeed.
+		_internals.statSync = fs.statSync as unknown as typeof _internals.statSync;
+		expect(resolveLaneContext(lanePath)?.parentProjectPath).toBe(
+			path.resolve(projectPath),
+		);
+	});
+
+	test('regression: a transient failure RETRIES and succeeds on the second attempt', () => {
+		// applyLanePermissions runs exactly once per instance from the config
+		// hook, so "we do not cache the failure, the next call can succeed" was
+		// false on the production path — there is no next call. An EMFILE while
+		// many lanes spawn at once therefore reverted that lane to the original
+		// unbounded-prompt hang. Detection now retries in-line.
+		const { lanePath, projectPath } = makeLane();
+		const warnings: string[] = [];
+		_internals.addDeferredWarning = (w: string) => {
+			warnings.push(w);
+		};
+		let calls = 0;
+		_internals.statSync = ((p2: string) => {
+			calls += 1;
+			if (calls === 1) {
+				const err = new Error(
+					'EMFILE: too many open files',
+				) as NodeJS.ErrnoException;
+				err.code = 'EMFILE';
+				throw err;
+			}
+			return fs.statSync(p2);
+		}) as unknown as typeof _internals.statSync;
+
+		// Resolves on the retry, in the SAME call — no second caller needed.
+		expect(resolveLaneContext(lanePath)?.parentProjectPath).toBe(
+			path.resolve(projectPath),
+		);
+		expect(calls).toBeGreaterThan(1);
+		// A recovered attempt must not warn.
+		expect(warnings).toEqual([]);
+	});
+
+	test('regression: exhausted retries warn even for a swwt-layout lane', () => {
+		// The warning used to be gated on hasWorktreeBaseSegment(), so exactly the
+		// layouts the path heuristic cannot see — a worktree_dir override and the
+		// Windows <tmp>/swwt fallback — got NO warning at all.
+		const swwtLane = path.join(root, 'swwt', 'ses_abc', '1.1');
+		fs.mkdirSync(swwtLane, { recursive: true });
+		expect(swwtLane).not.toContain(SWARM_WORKTREE_DIR_NAME);
+
+		const warnings: string[] = [];
+		_internals.addDeferredWarning = (w: string) => {
+			warnings.push(w);
+		};
+		let calls = 0;
+		_internals.statSync = (() => {
+			calls += 1;
+			const err = new Error(
+				'EACCES: permission denied',
+			) as NodeJS.ErrnoException;
+			err.code = 'EACCES';
+			throw err;
+		}) as unknown as typeof _internals.statSync;
+
+		expect(resolveLaneContext(swwtLane)).toBeNull();
+		// Retried, then gave up.
+		expect(calls).toBeGreaterThan(1);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0]).toContain(swwtLane);
+		expect(warnings[0]).toContain('may hang');
+	});
+
+	test('an exhausted I/O failure is still NOT cached (a later call may succeed)', () => {
+		const { lanePath, projectPath } = makeLane();
+		_internals.addDeferredWarning = () => {};
+		_internals.statSync = (() => {
+			const err = new Error('EMFILE') as NodeJS.ErrnoException;
+			err.code = 'EMFILE';
+			throw err;
+		}) as unknown as typeof _internals.statSync;
+		expect(resolveLaneContext(lanePath)).toBeNull();
+
+		_internals.statSync = fs.statSync as unknown as typeof _internals.statSync;
+		expect(resolveLaneContext(lanePath)?.parentProjectPath).toBe(
+			path.resolve(projectPath),
+		);
+	});
+
+	test('a genuine ENOENT IS cached (it is a real answer, not an I/O failure)', () => {
+		const warnings: string[] = [];
+		_internals.addDeferredWarning = (w: string) => {
+			warnings.push(w);
+		};
+		const missing = path.join(root, SWARM_WORKTREE_DIR_NAME, 'ses_e', 'gone');
+		expect(resolveLaneContext(missing)).toBeNull();
+		expect(warnings).toEqual([]);
+	});
+});

--- a/tests/unit/config/lane-permissions-config.test.ts
+++ b/tests/unit/config/lane-permissions-config.test.ts
@@ -1,0 +1,398 @@
+/**
+ * `applyLanePermissions` — the config-hook entry point.
+ *
+ * The hard requirement from the approved policy is that ORDINARY sessions are
+ * completely unaffected, so the negative case asserts deep equality of the
+ * whole config object against an untouched clone, not just "no
+ * external_directory key".
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { DEFAULT_WORKTREE_ISOLATION_CONFIG } from '../../../src/config/constants';
+import type { LaneContext } from '../../../src/config/lane-context';
+import {
+	_internals,
+	applyLanePermissions,
+} from '../../../src/config/lane-permissions';
+import { WorktreeIsolationConfigSchema } from '../../../src/config/schema';
+import { evaluateExternalDirectory } from '../../helpers/opencode-permission-model';
+
+const lane: LaneContext = {
+	lanePath: path.resolve('/tmp/wt/.swarm-worktrees/ses/1.1'),
+	parentProjectPath: path.resolve('/tmp/wt/my-project'),
+};
+
+let warnings: string[];
+let events: Array<{ file: string; record: Record<string, unknown> }>;
+let originals: typeof _internals;
+
+beforeEach(() => {
+	warnings = [];
+	events = [];
+	originals = { ..._internals };
+	_internals.addDeferredWarning = (w: string) => {
+		warnings.push(w);
+	};
+	_internals.mkdirSync = () => undefined;
+	_internals.appendFileSync = (p: string, data: string) => {
+		events.push({ file: p, record: JSON.parse(data) });
+	};
+});
+
+afterEach(() => {
+	Object.assign(_internals, originals);
+});
+
+function asLane(): void {
+	_internals.resolveLaneContext = () => lane;
+}
+function asOrdinary(): void {
+	_internals.resolveLaneContext = () => null;
+}
+
+/** A config shaped like the one the host hands the hook. */
+function makeConfig(): Record<string, unknown> {
+	return {
+		agent: { coder: { mode: 'subagent', permission: { task: 'allow' } } },
+		permission: { task: 'allow' },
+		command: { swarm: { template: '/swarm $ARGUMENTS' } },
+	};
+}
+
+describe('worktree.lane_permissions config knob', () => {
+	test('defaults to scoped_allow', () => {
+		expect(WorktreeIsolationConfigSchema.parse({}).lane_permissions).toBe(
+			'scoped_allow',
+		);
+	});
+
+	test.each(['scoped_allow', 'deny', 'off'] as const)('accepts %s', (value) => {
+		expect(
+			WorktreeIsolationConfigSchema.parse({ lane_permissions: value })
+				.lane_permissions,
+		).toBe(value);
+	});
+
+	test('rejects an unknown value', () => {
+		expect(
+			WorktreeIsolationConfigSchema.safeParse({ lane_permissions: 'yolo' })
+				.success,
+		).toBe(false);
+	});
+
+	test('the shipped default constant matches the schema default', () => {
+		// These two drifting is how a "default" silently becomes something else.
+		expect(DEFAULT_WORKTREE_ISOLATION_CONFIG.lane_permissions).toBe(
+			WorktreeIsolationConfigSchema.parse({}).lane_permissions,
+		);
+	});
+});
+
+describe('ordinary (non-lane) sessions are completely unaffected', () => {
+	test.each([
+		'scoped_allow',
+		'deny',
+		'off',
+	] as const)('mode=%s mutates nothing', (mode) => {
+		asOrdinary();
+		const config = makeConfig();
+		const before = structuredClone(config);
+		const result = applyLanePermissions(config, '/some/project', mode);
+		expect(result).toEqual({ lane: false });
+		expect(config).toEqual(before);
+		expect(warnings).toEqual([]);
+		expect(events).toEqual([]);
+	});
+
+	test('a config with NO permission key does not gain one', () => {
+		asOrdinary();
+		const config: Record<string, unknown> = { agent: {} };
+		applyLanePermissions(config, '/some/project', 'scoped_allow');
+		expect(Object.hasOwn(config, 'permission')).toBe(false);
+	});
+});
+
+describe('lane instance — scoped_allow', () => {
+	test('writes external_directory rules into the top-level permission block', () => {
+		asLane();
+		const config = makeConfig();
+		const result = applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+		expect(result.lane).toBe(true);
+		expect(result.mode).toBe('scoped_allow');
+		const permission = config.permission as Record<string, unknown>;
+		const rules = permission.external_directory as Record<string, string>;
+		expect(Object.keys(rules)[0]).toBe('*');
+		expect(rules['*']).toBe('deny');
+		expect(Object.keys(rules).length).toBeGreaterThan(1);
+	});
+
+	test('preserves unrelated permission keys (no assign-over-merge clobber)', () => {
+		asLane();
+		const config = makeConfig();
+		applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+		expect((config.permission as Record<string, unknown>).task).toBe('allow');
+	});
+
+	test('does NOT touch per-agent permission blocks', () => {
+		asLane();
+		const config = makeConfig();
+		const agentBefore = structuredClone(config.agent);
+		applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+		expect(config.agent).toEqual(agentBefore);
+	});
+
+	test('creates the permission block when the config has none', () => {
+		asLane();
+		const config: Record<string, unknown> = { agent: {} };
+		applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+		expect(
+			(config.permission as Record<string, unknown>).external_directory,
+		).toBeDefined();
+	});
+
+	test('emits exactly one advisory naming the remedy', () => {
+		asLane();
+		applyLanePermissions(makeConfig(), lane.lanePath, 'scoped_allow');
+		expect(warnings.length).toBe(1);
+		expect(warnings[0]).toContain('external_directory');
+		expect(warnings[0]).toContain(lane.lanePath);
+	});
+
+	test('records one structured decision event with allowlist + remedy', () => {
+		asLane();
+		applyLanePermissions(makeConfig(), lane.lanePath, 'scoped_allow');
+		expect(events.length).toBe(1);
+		const record = events[0].record;
+		expect(record.event).toBe('lane_permissions');
+		expect(record.decision).toBe('applied');
+		expect(record.mode).toBe('scoped_allow');
+		expect(record.lanePath).toBe(lane.lanePath);
+		expect(record.parentProjectPath).toBe(lane.parentProjectPath);
+		expect(Array.isArray(record.allowlist)).toBe(true);
+		expect((record.allowlist as unknown[]).length).toBeGreaterThan(0);
+		expect(String(record.remedy)).toContain('external_directory');
+		expect(events[0].file).toContain('.swarm');
+	});
+});
+
+describe('regression (HIGH-2): no configuration shape can leave a lane at "ask"', () => {
+	// `ask` is unanswerable in a lane (no TUI), so any surviving `ask` is a
+	// guaranteed indefinite hang. Every accepted config shape must resolve.
+	const outside = path.resolve('/definitely/not/allowlisted');
+
+	test.each([
+		[
+			'top-level string shorthand',
+			{ permission: { external_directory: 'ask' } },
+		],
+		['top-level map', { permission: { external_directory: { '*': 'ask' } } }],
+		[
+			'top-level per-pattern',
+			{ permission: { external_directory: { [`${outside}/*`]: 'ask' } } },
+		],
+	])('%s is downgraded to deny', (_label, extra) => {
+		asLane();
+		const config = { agent: {}, ...structuredClone(extra) } as Record<
+			string,
+			unknown
+		>;
+		applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+		const rules = (config.permission as Record<string, unknown>)
+			.external_directory as Record<string, string>;
+		for (const action of Object.values(rules)) {
+			expect(action).not.toBe('ask');
+		}
+		expect(
+			evaluateExternalDirectory({ external_directory: rules }, outside),
+		).toBe('deny');
+	});
+
+	test('a PER-AGENT external_directory map ask is downgraded (host merges it LAST)', () => {
+		// Without this, fix #1 is trivially bypassable: the host applies
+		// `a.merge(e.permission, a.fromConfig(agent.permission))` after the
+		// top-level block, so a per-agent `ask` is the rule that actually wins.
+		asLane();
+		const config: Record<string, unknown> = {
+			agent: {
+				coder: {
+					permission: { external_directory: { [`${outside}/*`]: 'ask' } },
+				},
+			},
+		};
+		applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+		const agentRules = (
+			(
+				(config.agent as Record<string, Record<string, unknown>>).coder
+					.permission as Record<string, unknown>
+			).external_directory as Record<string, string>
+		)[`${outside}/*`];
+		expect(agentRules).toBe('deny');
+	});
+
+	test('a PER-AGENT string shorthand ask is downgraded', () => {
+		asLane();
+		const config: Record<string, unknown> = {
+			agent: { coder: { permission: { external_directory: 'ask' } } },
+		};
+		applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+		expect(
+			(
+				(config.agent as Record<string, Record<string, unknown>>).coder
+					.permission as Record<string, unknown>
+			).external_directory,
+		).toBe('deny');
+	});
+
+	test('the downgrade is reported in both the advisory and the event record', () => {
+		asLane();
+		const config: Record<string, unknown> = {
+			permission: { external_directory: 'ask' },
+			agent: { coder: { permission: { external_directory: 'ask' } } },
+		};
+		applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+		expect(warnings[0]).toContain('"deny"');
+		const coerced = events[0].record.coercedAskPatterns as string[];
+		expect(coerced).toContain('*');
+		expect(coerced).toContain('coder.*');
+	});
+
+	test('per-agent allow/deny are left untouched', () => {
+		asLane();
+		const config: Record<string, unknown> = {
+			agent: {
+				coder: {
+					permission: {
+						external_directory: { '/a/*': 'allow', '/b/*': 'deny' },
+					},
+				},
+			},
+		};
+		applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+		expect(
+			(
+				(config.agent as Record<string, Record<string, unknown>>).coder
+					.permission as Record<string, unknown>
+			).external_directory,
+		).toEqual({ '/a/*': 'allow', '/b/*': 'deny' });
+		expect(events[0].record.coercedAskPatterns).toEqual([]);
+	});
+
+	test('a NON-lane session keeps its per-agent ask untouched', () => {
+		asOrdinary();
+		const config: Record<string, unknown> = {
+			agent: { coder: { permission: { external_directory: 'ask' } } },
+		};
+		const before = structuredClone(config);
+		applyLanePermissions(config, '/ordinary/project', 'scoped_allow');
+		expect(config).toEqual(before);
+	});
+});
+
+describe('regression (invariant 4): the event record anchors to the LANE ROOT', () => {
+	test('a NESTED instance directory still writes to <lane>/.swarm, not <lane>/src/.swarm', () => {
+		// resolveLaneContext deliberately walks ancestors, so ctx.directory can be
+		// BELOW the lane root. Using it verbatim would write
+		// `<lane>/src/.swarm/events.jsonl` — a `.swarm/` under a source
+		// subdirectory, which AGENTS.md invariant 4 forbids.
+		asLane();
+		const nested = path.join(lane.lanePath, 'src', 'deep');
+		applyLanePermissions(makeConfig(), nested, 'scoped_allow');
+
+		expect(events.length).toBe(1);
+		const file = events[0].file;
+		expect(file).toBe(path.join(lane.lanePath, '.swarm', 'events.jsonl'));
+		expect(file).not.toContain(path.join('src', '.swarm'));
+	});
+
+	test('the same anchoring applies on the "off" (skipped) path', () => {
+		asLane();
+		applyLanePermissions(makeConfig(), path.join(lane.lanePath, 'src'), 'off');
+		expect(events[0].file).toBe(
+			path.join(lane.lanePath, '.swarm', 'events.jsonl'),
+		);
+	});
+});
+
+describe('the event record must report the rules actually emitted', () => {
+	test('every allowlist pattern in the event equals a real key in the rule map', () => {
+		// The rule map and the event record used to derive each pattern
+		// independently (two `laneDirectoryPattern` calls per entry, each doing
+		// its own `realpathSync.native`). If those ever diverged, the event log —
+		// the whole observability story for this feature — would misreport what
+		// was granted. The pattern is now computed once per allowlist entry and
+		// both consumers read it, so this asserts they agree.
+		asLane();
+		const config = makeConfig();
+		applyLanePermissions(config, lane.lanePath, 'scoped_allow');
+
+		const rules = (config.permission as Record<string, unknown>)
+			.external_directory as Record<string, string>;
+		const recorded = events[0].record.allowlist as Array<{
+			pattern: string;
+			reason: string;
+		}>;
+
+		expect(recorded.length).toBeGreaterThan(0);
+		for (const entry of recorded) {
+			expect(Object.hasOwn(rules, entry.pattern)).toBe(true);
+			expect(rules[entry.pattern]).toBe('allow');
+		}
+		// And every non-catch-all allow rule is accounted for in the record.
+		const allowKeys = Object.keys(rules).filter(
+			(k) => k !== '*' && rules[k] === 'allow',
+		);
+		expect(new Set(recorded.map((e) => e.pattern))).toEqual(new Set(allowKeys));
+	});
+});
+
+describe('lane instance — deny', () => {
+	test('emits only the catch-all deny', () => {
+		asLane();
+		const config = makeConfig();
+		applyLanePermissions(config, lane.lanePath, 'deny');
+		expect(
+			(config.permission as Record<string, unknown>).external_directory,
+		).toEqual({ '*': 'deny' });
+	});
+});
+
+describe('lane instance — off', () => {
+	test('changes nothing but records why the lane may hang', () => {
+		asLane();
+		const config = makeConfig();
+		const before = structuredClone(config);
+		const result = applyLanePermissions(config, lane.lanePath, 'off');
+		expect(result).toEqual({ lane: true, mode: 'off' });
+		expect(config).toEqual(before);
+		expect(warnings).toEqual([]);
+		expect(events.length).toBe(1);
+		expect(events[0].record.decision).toBe('skipped');
+		expect(String(events[0].record.reason)).toContain('hang');
+	});
+});
+
+describe('observability failures never break plugin init', () => {
+	test('an events.jsonl write failure is swallowed and rules still applied', () => {
+		asLane();
+		_internals.appendFileSync = () => {
+			throw new Error('EROFS: read-only file system');
+		};
+		const config = makeConfig();
+		expect(() =>
+			applyLanePermissions(config, lane.lanePath, 'scoped_allow'),
+		).not.toThrow();
+		expect(
+			(config.permission as Record<string, unknown>).external_directory,
+		).toBeDefined();
+	});
+
+	test('an mkdir failure is swallowed', () => {
+		asLane();
+		_internals.mkdirSync = () => {
+			throw new Error('EACCES');
+		};
+		expect(() =>
+			applyLanePermissions(makeConfig(), lane.lanePath, 'scoped_allow'),
+		).not.toThrow();
+	});
+});

--- a/tests/unit/config/lane-permissions-plugin-hook.test.ts
+++ b/tests/unit/config/lane-permissions-plugin-hook.test.ts
@@ -1,0 +1,148 @@
+/**
+ * End-to-end wiring: the REAL plugin `config` hook applies lane permissions.
+ *
+ * The guardrail's other wiring check is a source regex over `src/index.ts`,
+ * which would still pass if the `applyLanePermissions` call moved behind an
+ * early return, was wrapped in a disabled branch, or ran after the hook had
+ * already returned. This test invokes `OpenCodeSwarm.server(...)` and then the
+ * returned `config` hook itself, so only real behaviour can satisfy it.
+ *
+ * Both directions are asserted: a lane instance gets rules, and an ordinary
+ * instance is left byte-identical.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+	type LaneContext,
+	_internals as laneContextInternals,
+} from '../../../src/config/lane-context';
+import OpenCodeSwarm from '../../../src/index';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+let dir: string;
+let cleanup: () => void;
+const realStat = laneContextInternals.statSync;
+const realRead = laneContextInternals.readFileSync;
+const realClear = laneContextInternals.clearCache;
+
+beforeEach(() => {
+	({ dir, cleanup } = createSafeTestDir('lane-hook-'));
+	fs.mkdirSync(path.join(dir, '.opencode'), { recursive: true });
+	fs.mkdirSync(path.join(dir, '.swarm'), { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, '.opencode', 'opencode-swarm.json'),
+		JSON.stringify({ quiet: true }),
+		'utf-8',
+	);
+	realClear();
+});
+
+afterEach(() => {
+	laneContextInternals.statSync = realStat;
+	laneContextInternals.readFileSync = realRead;
+	realClear();
+	cleanup();
+});
+
+/** Runs the real plugin server() and returns its `config` hook. */
+async function loadConfigHook(): Promise<
+	(cfg: Record<string, unknown>) => Promise<void> | void
+> {
+	const hooks = await OpenCodeSwarm.server({
+		client: {} as Record<string, unknown>,
+		project: {} as Record<string, unknown>,
+		directory: dir,
+		worktree: dir,
+		serverUrl: new URL('http://localhost:3000'),
+		$: {} as Record<string, unknown>,
+	} as never);
+	const hook = (hooks as Record<string, unknown>).config;
+	expect(typeof hook).toBe('function');
+	return hook as (cfg: Record<string, unknown>) => Promise<void> | void;
+}
+
+/** Forces lane detection to report `dir` as a lane, without a real git tree. */
+function forceLane(): LaneContext {
+	const lane: LaneContext = {
+		lanePath: path.resolve(dir),
+		parentProjectPath: path.resolve(path.join(dir, '..', 'parent-project')),
+	};
+	laneContextInternals.statSync = ((p: string) =>
+		p === path.join(path.resolve(dir), '.git')
+			? { isFile: () => true }
+			: realStat(p)) as typeof laneContextInternals.statSync;
+	laneContextInternals.readFileSync = ((p: string, enc: BufferEncoding) => {
+		const gitDir = path.join(lane.parentProjectPath, '.git', 'worktrees', 'l1');
+		if (p === path.join(path.resolve(dir), '.git')) {
+			return `gitdir: ${gitDir.split(path.sep).join('/')}\n`;
+		}
+		if (p === path.join(gitDir, 'HEAD')) {
+			return 'ref: refs/heads/swarm/lane/ses_0410b724cffeApmZIOs5VH9XsN/1.1\n';
+		}
+		if (p === path.join(gitDir, 'commondir')) return '../..\n';
+		return realRead(p, enc);
+	}) as typeof laneContextInternals.readFileSync;
+	realClear();
+	return lane;
+}
+
+describe('plugin config hook — real invocation', () => {
+	test('an ordinary instance is left byte-identical', async () => {
+		const hook = await loadConfigHook();
+		const config: Record<string, unknown> = {
+			permission: { task: 'allow' },
+			agent: { coder: { permission: { external_directory: 'ask' } } },
+		};
+		const beforePermission = structuredClone(config.permission);
+		const beforeAgent = structuredClone(config.agent);
+
+		await hook(config);
+
+		// The hook legitimately adds agents/commands; what must NOT change is the
+		// permission surface.
+		expect(config.permission).toEqual(beforePermission);
+		expect(
+			(config.agent as Record<string, Record<string, unknown>>).coder,
+		).toEqual((beforeAgent as Record<string, Record<string, unknown>>).coder);
+	});
+
+	test('a lane instance gets external_directory rules with the catch-all deny', async () => {
+		const lane = forceLane();
+		const hook = await loadConfigHook();
+		const config: Record<string, unknown> = { permission: { task: 'allow' } };
+
+		await hook(config);
+
+		const permission = config.permission as Record<string, unknown>;
+		const rules = permission.external_directory as Record<string, string>;
+		expect(rules).toBeDefined();
+		expect(Object.keys(rules)[0]).toBe('*');
+		expect(rules['*']).toBe('deny');
+		// The parent project must be granted, canonicalised the way the host asks.
+		const parentPattern = Object.keys(rules).find((k) =>
+			k.toLowerCase().startsWith(lane.parentProjectPath.toLowerCase()),
+		);
+		expect(parentPattern).toBeDefined();
+		expect(rules[parentPattern as string]).toBe('allow');
+		// Unrelated keys survive.
+		expect(permission.task).toBe('allow');
+	});
+
+	test('a lane instance downgrades a per-agent external_directory ask', async () => {
+		forceLane();
+		const hook = await loadConfigHook();
+		const config: Record<string, unknown> = {
+			agent: { coder: { permission: { external_directory: 'ask' } } },
+		};
+
+		await hook(config);
+
+		expect(
+			(
+				(config.agent as Record<string, Record<string, unknown>>).coder
+					.permission as Record<string, unknown>
+			).external_directory,
+		).toBe('deny');
+	});
+});

--- a/tests/unit/config/lane-permissions-plugin-hook.test.ts
+++ b/tests/unit/config/lane-permissions-plugin-hook.test.ts
@@ -8,25 +8,38 @@
  * returned `config` hook itself, so only real behaviour can satisfy it.
  *
  * Both directions are asserted: a lane instance gets rules, and an ordinary
- * instance is left byte-identical.
+ * instance's permission surface is unchanged.
+ *
+ * The environment is ISOLATED (`createIsolatedTestEnv`). Without it the plugin
+ * loads the developer's real global `opencode-swarm.json`, so the generated
+ * agent set — and therefore this test's outcome — differs between a dev box and
+ * CI. That is exactly how the PR #2015 failure hid: a local `swarms` block
+ * prefixed every agent name, so the fixture agent was never clobbered.
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { getAgentConfigs } from '../../../src/agents';
 import {
 	type LaneContext,
 	_internals as laneContextInternals,
 } from '../../../src/config/lane-context';
+import { PluginConfigSchema } from '../../../src/config/schema';
 import OpenCodeSwarm from '../../../src/index';
+import { createIsolatedTestEnv } from '../../helpers/isolated-test-env';
 import { createSafeTestDir } from '../../helpers/safe-test-dir';
 
 let dir: string;
 let cleanup: () => void;
+let envCleanup: () => void;
 const realStat = laneContextInternals.statSync;
 const realRead = laneContextInternals.readFileSync;
 const realClear = laneContextInternals.clearCache;
 
 beforeEach(() => {
+	// Isolate XDG/HOME/APPDATA so the plugin cannot read the developer's real
+	// global config; without this the generated agent set is machine-dependent.
+	({ cleanup: envCleanup } = createIsolatedTestEnv());
 	({ dir, cleanup } = createSafeTestDir('lane-hook-'));
 	fs.mkdirSync(path.join(dir, '.opencode'), { recursive: true });
 	fs.mkdirSync(path.join(dir, '.swarm'), { recursive: true });
@@ -43,6 +56,7 @@ afterEach(() => {
 	laneContextInternals.readFileSync = realRead;
 	realClear();
 	cleanup();
+	envCleanup();
 });
 
 /** Runs the real plugin server() and returns its `config` hook. */
@@ -87,24 +101,75 @@ function forceLane(): LaneContext {
 	return lane;
 }
 
+/**
+ * An agent name the plugin does NOT generate.
+ *
+ * FOUND BY CI (PR #2015). These tests originally used `coder`, which the plugin
+ * DOES generate — `Object.assign(agentConfig, agents)` in the config hook
+ * therefore replaced the fixture wholesale, dropping its `permission` key and
+ * adding the generated prompt (hence the "SKILLS HANDLING" text in the CI diff)
+ * and, because generated `coder` is a SUBAGENT, leaving no `permission` key at
+ * all (hence the TypeError).
+ *
+ * It passed locally purely by accident of the developer's global config, which
+ * declares a `swarms` block — multi-swarm configs PREFIX every agent name
+ * (`mega_coder`, `local_coder`, ...), so no plain `coder` was generated and the
+ * fixture survived. CI has no such config, so plain `coder` is generated.
+ *
+ * The guard below asserts the chosen name really is un-generated, so this
+ * cannot silently rot if the agent set ever grows.
+ */
+const USER_AGENT_NAME = 'custom_user_agent';
+
 describe('plugin config hook — real invocation', () => {
-	test('an ordinary instance is left byte-identical', async () => {
+	test('the fixture agent name is one the plugin never generates', () => {
+		const generated = getAgentConfigs(PluginConfigSchema.parse({}));
+		expect(Object.hasOwn(generated, USER_AGENT_NAME)).toBe(false);
+		// Sanity: the plugin really does generate agents, so this is a live check
+		// rather than one that passes because the set is empty.
+		expect(Object.keys(generated).length).toBeGreaterThan(5);
+		// And pin the trap that caused the CI failure.
+		expect(Object.hasOwn(generated, 'coder')).toBe(true);
+	});
+
+	test('an ordinary instance keeps its permission surface unchanged', async () => {
 		const hook = await loadConfigHook();
 		const config: Record<string, unknown> = {
 			permission: { task: 'allow' },
-			agent: { coder: { permission: { external_directory: 'ask' } } },
+			agent: {
+				[USER_AGENT_NAME]: { permission: { external_directory: 'ask' } },
+			},
 		};
 		const beforePermission = structuredClone(config.permission);
-		const beforeAgent = structuredClone(config.agent);
+		const beforeAgent = structuredClone(
+			(config.agent as Record<string, unknown>)[USER_AGENT_NAME],
+		);
 
 		await hook(config);
 
-		// The hook legitimately adds agents/commands; what must NOT change is the
-		// permission surface.
+		// The hook legitimately ADDS its own agents and a /swarm command, so
+		// whole-config equality was never the right claim. What must not change
+		// outside a lane is the PERMISSION SURFACE:
+		//  - the top-level permission block, and
+		//  - the permission of an agent the plugin does not own.
 		expect(config.permission).toEqual(beforePermission);
 		expect(
-			(config.agent as Record<string, Record<string, unknown>>).coder,
-		).toEqual((beforeAgent as Record<string, Record<string, unknown>>).coder);
+			(config.agent as Record<string, Record<string, unknown>>)[
+				USER_AGENT_NAME
+			],
+		).toEqual(beforeAgent as Record<string, unknown>);
+		// Specifically: an ordinary session must NOT get external_directory rules.
+		expect(
+			Object.hasOwn(config.permission as object, 'external_directory'),
+		).toBe(false);
+		// And the user's own `ask` must survive untouched outside a lane.
+		expect(
+			(
+				(config.agent as Record<string, Record<string, unknown>>)[
+					USER_AGENT_NAME
+				].permission as Record<string, unknown>
+			).external_directory,
+		).toBe('ask');
 	});
 
 	test('a lane instance gets external_directory rules with the catch-all deny', async () => {
@@ -133,15 +198,18 @@ describe('plugin config hook — real invocation', () => {
 		forceLane();
 		const hook = await loadConfigHook();
 		const config: Record<string, unknown> = {
-			agent: { coder: { permission: { external_directory: 'ask' } } },
+			agent: {
+				[USER_AGENT_NAME]: { permission: { external_directory: 'ask' } },
+			},
 		};
 
 		await hook(config);
 
 		expect(
 			(
-				(config.agent as Record<string, Record<string, unknown>>).coder
-					.permission as Record<string, unknown>
+				(config.agent as Record<string, Record<string, unknown>>)[
+					USER_AGENT_NAME
+				].permission as Record<string, unknown>
 			).external_directory,
 		).toBe('deny');
 	});

--- a/tests/unit/config/lane-permissions-precedence.test.ts
+++ b/tests/unit/config/lane-permissions-precedence.test.ts
@@ -331,8 +331,14 @@ describe('explicit user configuration always wins', () => {
 		const out = buildLaneExternalDirectoryRules('scoped_allow', lane, 'ask');
 		expect(out?.rules['*']).toBe('deny');
 		expect(out?.coercedAskPatterns).toEqual(['*']);
+		// Multi-segment: a single-letter first segment ('/x') is rewritten by the
+		// host's windowsPath under POSIX, so the assertion would hold for a
+		// cwd-anchored path rather than the one named here.
 		expect(
-			evaluateExternalDirectory(asPermission(out?.rules ?? null), '/x'),
+			evaluateExternalDirectory(
+				asPermission(out?.rules ?? null),
+				path.resolve('/definitely/not/allowlisted'),
+			),
 		).toBe('deny');
 	});
 

--- a/tests/unit/config/lane-permissions-precedence.test.ts
+++ b/tests/unit/config/lane-permissions-precedence.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Lane `external_directory` rule PRECEDENCE.
+ *
+ * Emission order (which IS evaluation order — the host uses `findLast`),
+ * explicit-user-config override, host base-allow preservation, and the three
+ * config-knob modes. Allowlist CONSTRUCTION lives in
+ * `lane-permissions.test.ts`.
+ *
+ * Every behavioural assertion runs the emitted rules through
+ * `tests/helpers/opencode-permission-model.ts`, a verbatim transcription of the
+ * host's own `Wildcard.match` / `fromConfig` / `merge` / `evaluate`. That is
+ * deliberate: the ordering contract (catch-all deny FIRST, allows after) is the
+ * single thing most likely to be got backwards, and asserting on our own object
+ * shape would not catch it.
+ */
+import { describe, expect, test } from 'bun:test';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getHostDataDir } from '../../../src/config/cache-paths';
+import {
+	asPermission,
+	build,
+	buildLaneExternalDirectoryRules,
+	lane,
+} from '../../helpers/lane-permissions-fixture';
+import {
+	evaluateExternalDirectory,
+	hostFromConfig,
+} from '../../helpers/opencode-permission-model';
+
+describe('rule ordering — verified against the host evaluator', () => {
+	const rules = build('scoped_allow');
+
+	test('the catch-all deny is emitted FIRST (findLast means later wins)', () => {
+		const keys = Object.keys(rules ?? {});
+		expect(keys[0]).toBe('*');
+		expect(rules?.['*']).toBe('deny');
+		expect(keys.length).toBeGreaterThan(1);
+	});
+
+	test('allowlisted directories evaluate to allow', () => {
+		const permission = asPermission(rules);
+		expect(evaluateExternalDirectory(permission, lane.parentProjectPath)).toBe(
+			'allow',
+		);
+		expect(evaluateExternalDirectory(permission, lane.lanePath)).toBe('allow');
+		expect(
+			evaluateExternalDirectory(permission, path.join(os.tmpdir(), 'opencode')),
+		).toBe('allow');
+	});
+
+	test('the broad OS temp root is DENIED', () => {
+		expect(evaluateExternalDirectory(asPermission(rules), os.tmpdir())).toBe(
+			'deny',
+		);
+	});
+
+	test('nested paths under an allowlisted directory also allow (dotAll `*`)', () => {
+		const permission = asPermission(rules);
+		expect(
+			evaluateExternalDirectory(
+				permission,
+				path.join(lane.parentProjectPath, 'src', 'deep', 'nested'),
+			),
+		).toBe('allow');
+	});
+
+	test('a path outside the allowlist DENIES — it is never left at "ask"', () => {
+		const permission = asPermission(rules);
+		const outside = path.resolve(
+			path.join(os.tmpdir(), '..', 'not-allowed-xyz'),
+		);
+		const action = evaluateExternalDirectory(permission, outside);
+		expect(action).toBe('deny');
+		// The whole point of the fix: nothing may remain answerable-only.
+		expect(action).not.toBe('ask');
+	});
+
+	test('FALSIFIABILITY: emitting the catch-all deny LAST would deny everything', () => {
+		// Reproduce the ordering mistake this module exists to prevent.
+		const { '*': catchAll, ...allows } = rules ?? {};
+		const reversed = { ...allows, '*': catchAll } as Record<string, string>;
+		expect(
+			evaluateExternalDirectory(asPermission(reversed), lane.parentProjectPath),
+		).toBe('deny');
+		// ...whereas the real ordering allows it. If both branches ever agree,
+		// this test has stopped proving anything.
+		expect(
+			evaluateExternalDirectory(asPermission(rules), lane.parentProjectPath),
+		).toBe('allow');
+	});
+
+	test('BASELINE: without our rules the host default leaves the request at "ask"', () => {
+		// This is the hang. Confirms the fixture reproduces the real defect.
+		expect(evaluateExternalDirectory({}, lane.parentProjectPath)).toBe('ask');
+	});
+});
+
+describe('regression (MEDIUM-4): the lane ruleset must not revoke host base allows', () => {
+	// The host base-allows four families for EVERY agent (Agent.state, offset
+	// 100811506):
+	//   q = [A.GLOB, join(Global.Path.tmp,'*'), ...Skill.dirs(),
+	//        ...config-reference dirs]
+	// NOTE the third family is SKILL directories, not config directories: the
+	// Agent chunk imports `zr as _` from chunk-mdqr1haw.js and `zr` is the Skill
+	// namespace (the one exposing `dirs`). An earlier version of this test said
+	// `Config.directories()` and asserted the config dirs as "base allows
+	// preserved" — a false model of the host, the same class of error as the
+	// ancestor-`.opencode` claim corrected below.
+	//
+	// Our catch-all deny sits in front of these, so anything we do not re-grant
+	// is silently REVOKED inside a lane. This test pins exactly which survive.
+	const toolOutputGlob = path
+		.join(os.homedir(), '.local', 'share', 'opencode', 'tool-output', '*')
+		.split(path.sep)
+		.join('/');
+
+	const hostBaseAllowDirs = [
+		// Global.Path.tmp — binary offset 107378900: join(os.tmpdir(),'opencode').
+		path.join(os.tmpdir(), 'opencode'),
+		// Skill.dirs() — every directory skill discovery found. The user-level
+		// `.claude/skills` root is the one the field log hung on.
+		path.resolve(os.homedir(), '.claude', 'skills'),
+		path.resolve(lane.parentProjectPath, '.opencode', 'skills'),
+	];
+
+	test.each(
+		hostBaseAllowDirs,
+	)('host base allow %s is preserved inside a lane', (dir) => {
+		const action = evaluateExternalDirectory(
+			asPermission(build('scoped_allow')),
+			dir,
+			{ baseAllowDirs: hostBaseAllowDirs, toolOutputGlob },
+		);
+		expect(action).toBe('allow');
+	});
+
+	test('the tool-output glob survives via the host re-append, not via our rules', () => {
+		// Our catch-all uses pattern '*', which does NOT satisfy the host's exact
+		// `action==='deny' && pattern===A.GLOB` check, so the re-append still
+		// fires and lands last.
+		const action = evaluateExternalDirectory(
+			asPermission(build('scoped_allow')),
+			path.dirname(toolOutputGlob),
+			{ baseAllowDirs: hostBaseAllowDirs, toolOutputGlob },
+		);
+		expect(action).toBe('allow');
+	});
+
+	test('the config dirs are a deliberate WIDENING, not a host base allow', () => {
+		// They are granted (a lane reads global agent/command/skill definitions
+		// from them) but the host does NOT base-allow them, so this is us
+		// widening on purpose. Recorded so the distinction cannot quietly invert.
+		const p = asPermission(build('scoped_allow'));
+		expect(
+			evaluateExternalDirectory(
+				p,
+				path.resolve(os.homedir(), '.config', 'opencode'),
+			),
+		).toBe('allow');
+	});
+
+	test('the ~/.opencode TREE is not granted, but its skill roots are', () => {
+		// external_directory has no read/write split, and OpenCode's GitLab OAuth
+		// helper stores credentials at ~/.opencode/auth.json when XDG_DATA_HOME is
+		// unset (the default on Windows and macOS). Granting the tree would put a
+		// credential file inside a lane's WRITE grant. The skill subpaths a lane
+		// actually needs are granted individually.
+		const p = asPermission(build('scoped_allow'));
+		expect(
+			evaluateExternalDirectory(p, path.join(os.homedir(), '.opencode')),
+		).toBe('deny');
+		expect(
+			evaluateExternalDirectory(
+				p,
+				path.join(os.homedir(), '.opencode', 'skills'),
+			),
+		).toBe('allow');
+	});
+
+	test('no allowlist entry contains a known credential file', () => {
+		// Belt-and-braces against a future widening re-admitting one.
+		const p = asPermission(build('scoped_allow'));
+		for (const dir of [
+			path.resolve(getHostDataDir()), // primary Auth service auth.json
+			path.join(os.homedir(), '.opencode'), // GitLab OAuth helper auth.json
+		]) {
+			expect(evaluateExternalDirectory(p, dir)).toBe('deny');
+		}
+	});
+
+	test('DISPOSITIONED revocation: config.references dirs, and ONLY those', () => {
+		// Exactly ONE host base-allow family is not re-granted:
+		// `config.references` directories, which a host service resolves from
+		// user config and which the plugin config hook cannot obtain without
+		// reimplementing that resolution.
+		//
+		// An earlier version of this test also claimed `.opencode` directories in
+		// ancestors ABOVE the parent project were revoked. That was a false model
+		// of the host. `ConfigPaths.directories` (offset 103303216) is:
+		//   up({ targets: ['.opencode'], start: directory, stop: worktree })
+		// — bounded by the worktree, so it never walks past it and those
+		// ancestors were never base-allowed in the first place. Nothing to
+		// revoke, and nothing to re-grant.
+		const referenceDir = path.resolve(path.join(os.tmpdir(), 'shared-refs'));
+		expect(
+			evaluateExternalDirectory(
+				asPermission(build('scoped_allow')),
+				referenceDir,
+				{ baseAllowDirs: [...hostBaseAllowDirs, referenceDir] },
+			),
+		).toBe('deny');
+	});
+});
+
+describe('config-knob modes', () => {
+	test('scoped_allow: allowlist allows, everything else denies', () => {
+		const p = asPermission(build('scoped_allow'));
+		expect(evaluateExternalDirectory(p, lane.parentProjectPath)).toBe('allow');
+		expect(evaluateExternalDirectory(p, path.resolve('/somewhere/else'))).toBe(
+			'deny',
+		);
+	});
+
+	test('deny: everything denies, including the parent project', () => {
+		const rules = build('deny');
+		expect(rules).toEqual({ '*': 'deny' });
+		const p = asPermission(rules);
+		expect(evaluateExternalDirectory(p, lane.parentProjectPath)).toBe('deny');
+		expect(evaluateExternalDirectory(p, os.tmpdir())).toBe('deny');
+	});
+
+	test('off: returns null so the caller changes nothing', () => {
+		expect(build('off')).toBeNull();
+	});
+});
+
+describe('explicit user configuration always wins', () => {
+	test('a user deny for a subpath beats our allow', () => {
+		const secret = path.join(lane.parentProjectPath, 'secrets');
+		const rules = build('scoped_allow', { [`${secret}/*`]: 'deny' });
+		const p = asPermission(rules);
+		expect(evaluateExternalDirectory(p, secret)).toBe('deny');
+		// ...but the rest of the project is still reachable.
+		expect(
+			evaluateExternalDirectory(p, path.join(lane.parentProjectPath, 'src')),
+		).toBe('allow');
+	});
+
+	test('a user allow for an outside dir beats our catch-all deny', () => {
+		const extra = path.resolve('/opt/shared-lib');
+		const p = asPermission(build('scoped_allow', { [`${extra}/*`]: 'allow' }));
+		expect(evaluateExternalDirectory(p, extra)).toBe('allow');
+	});
+
+	test('a user `external_directory: "allow"` shorthand still means allow-all', () => {
+		const p = asPermission(build('scoped_allow', 'allow'));
+		expect(evaluateExternalDirectory(p, path.resolve('/anywhere'))).toBe(
+			'allow',
+		);
+	});
+
+	// The previous version of this test asserted that a user `'*'` "replaces our
+	// catch-all value IN PLACE" — pinning the exact mechanism that caused a
+	// fail-open. In-place reassignment keeps the key at index 0, so under the
+	// host's `findLast` the plugin allowlist outranked the operator's explicit
+	// deny-all and silently re-granted WRITE access. Position IS precedence, so
+	// these tests assert emitted KEY ORDER, not just evaluated outcomes.
+
+	test('regression (HIGH-2): an explicit deny-all from the operator WINS', () => {
+		for (const existing of ['deny', { '*': 'deny' }] as const) {
+			const rules = build('scoped_allow', existing);
+			const keys = Object.keys(rules ?? {});
+			// The user's rule must land LAST, not keep our catch-all's slot.
+			expect(keys[keys.length - 1]).toBe('*');
+			expect(rules?.['*']).toBe('deny');
+			const permission = asPermission(rules);
+			expect(
+				evaluateExternalDirectory(permission, lane.parentProjectPath),
+			).toBe('deny');
+			expect(
+				evaluateExternalDirectory(
+					permission,
+					path.resolve(os.homedir(), '.claude/skills'),
+				),
+			).toBe('deny');
+		}
+	});
+
+	test('a user `{"*": "allow"}` map lands last and means allow-all', () => {
+		const rules = build('scoped_allow', { '*': 'allow' });
+		const keys = Object.keys(rules ?? {});
+		expect(keys[keys.length - 1]).toBe('*');
+		expect(rules?.['*']).toBe('allow');
+		expect(
+			evaluateExternalDirectory(asPermission(rules), path.resolve('/anywhere')),
+		).toBe('allow');
+	});
+
+	test('EMITTED KEY ORDER: catch-all first, allowlist next, user entries last', () => {
+		const userPattern = path.join(path.resolve('/user/dir'), '*');
+		const rules =
+			build('scoped_allow', { [userPattern]: 'deny', '*': 'deny' }) ?? {};
+		const keys = Object.keys(rules);
+		// Our catch-all was emitted first but the user re-specified '*', so it
+		// moves to the end. Both user keys must sit after every allowlist entry.
+		const lastAllowlistIndex = Math.max(
+			...keys
+				.map((k, i) => (rules[k] === 'allow' ? i : -1))
+				.filter((i) => i >= 0),
+		);
+		expect(keys.indexOf(userPattern)).toBeGreaterThan(lastAllowlistIndex);
+		expect(keys.indexOf('*')).toBeGreaterThan(lastAllowlistIndex);
+	});
+
+	test('a coerced ask also lands last (the coercion branch uses the same helper)', () => {
+		const rules = build('scoped_allow', { '*': 'ask' }) ?? {};
+		const keys = Object.keys(rules);
+		expect(keys[keys.length - 1]).toBe('*');
+		expect(rules['*']).toBe('deny');
+		expect(
+			evaluateExternalDirectory(asPermission(rules), lane.parentProjectPath),
+		).toBe('deny');
+	});
+
+	test('regression (HIGH-2): a user "ask" is coerced to deny — it would hang the lane', () => {
+		// Prior behaviour honoured `ask` verbatim, silently reinstating the exact
+		// indefinite hang this module exists to remove: a lane has no TUI, so the
+		// resulting prompt could never be answered, yet the code reported
+		// decision:"applied".
+		const out = buildLaneExternalDirectoryRules('scoped_allow', lane, 'ask');
+		expect(out?.rules['*']).toBe('deny');
+		expect(out?.coercedAskPatterns).toEqual(['*']);
+		expect(
+			evaluateExternalDirectory(asPermission(out?.rules ?? null), '/x'),
+		).toBe('deny');
+	});
+
+	test('regression (HIGH-2): a per-pattern "ask" is coerced and reported', () => {
+		const target = path.resolve('/opt/thing');
+		const out = buildLaneExternalDirectoryRules('scoped_allow', lane, {
+			[`${target}/*`]: 'ask',
+		});
+		expect(out?.coercedAskPatterns).toEqual([`${target}/*`]);
+		expect(
+			evaluateExternalDirectory(asPermission(out?.rules ?? null), target),
+		).toBe('deny');
+	});
+
+	test('user allow/deny are NOT coerced — only "ask" is', () => {
+		const out = buildLaneExternalDirectoryRules('scoped_allow', lane, {
+			'/a/*': 'allow',
+			'/b/*': 'deny',
+		});
+		expect(out?.coercedAskPatterns).toEqual([]);
+		expect(out?.rules['/a/*']).toBe('allow');
+		expect(out?.rules['/b/*']).toBe('deny');
+	});
+
+	test('no configuration means nothing is reported as coerced', () => {
+		expect(
+			buildLaneExternalDirectoryRules('scoped_allow', lane)?.coercedAskPatterns,
+		).toEqual([]);
+	});
+
+	test('a non-object, non-string existing value is ignored safely', () => {
+		for (const bogus of [42, [], true, null, undefined]) {
+			const rules = build('scoped_allow', bogus);
+			expect(rules?.['*']).toBe('deny');
+		}
+	});
+});

--- a/tests/unit/config/lane-permissions.test.ts
+++ b/tests/unit/config/lane-permissions.test.ts
@@ -26,6 +26,7 @@ import {
 	evaluateExternalDirectory,
 	hostFromConfig,
 } from '../../helpers/opencode-permission-model';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
 
 const { laneDirectoryPattern, renderLanePermissionAdvisory } = _test_exports;
 
@@ -196,8 +197,17 @@ describe('regression: skill roots mirror the host glob, not half of it', () => {
 
 describe('pattern construction', () => {
 	test('laneDirectoryPattern covers the subtree', () => {
-		const dir = path.resolve('/a/b');
-		expect(laneDirectoryPattern(dir)).toBe(path.join(dir, '*'));
+		// A REAL directory. A synthetic '/a/b' collides with the host's
+		// windowsPath single-letter drive rewrite under POSIX ('/a/b' -> 'A:/b'),
+		// which path.resolve then re-anchors under cwd — see
+		// tests/unit/config/host-path.test.ts for the pinned behaviour.
+		const { dir, cleanup } = createSafeTestDir('lane-pattern-');
+		try {
+			const resolved = path.resolve(dir);
+			expect(laneDirectoryPattern(resolved)).toBe(path.join(resolved, '*'));
+		} finally {
+			cleanup();
+		}
 	});
 
 	test('emitted patterns survive host fromConfig unchanged (no ~ expansion surprises)', () => {

--- a/tests/unit/config/lane-permissions.test.ts
+++ b/tests/unit/config/lane-permissions.test.ts
@@ -11,9 +11,13 @@
  * host's own `Wildcard.match` / `fromConfig` / `merge` / `evaluate`.
  */
 import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { getHostDataDir } from '../../../src/config/cache-paths';
+import {
+	getHostDataDir,
+	getHostSkillCacheDir,
+} from '../../../src/config/cache-paths';
 import { _test_exports } from '../../../src/config/lane-permissions';
 import {
 	asPermission,
@@ -158,6 +162,70 @@ describe('regression: skill roots mirror the host glob, not half of it', () => {
 		}
 	});
 
+	/** Rules built with an explicit `skills.urls` list. */
+	const withUrls = (urls: string[]) =>
+		asPermission(
+			buildLaneExternalDirectoryRules(
+				'scoped_allow',
+				lane,
+				undefined,
+				buildLaneAllowlist(lane, [], urls),
+			)?.rules ?? null,
+		);
+
+	test('the URL-skill cache is granted ONLY when skills.urls is configured', () => {
+		// The host pulls `skills.urls` and adds each pulled skill's directory to
+		// Skill.dirs() (offset ~102994300), part of the per-agent base allow — so
+		// with URLs configured a lane must reach the cache.
+		const configured = withUrls(['https://example.com/skills/']);
+		expect(evaluateExternalDirectory(configured, getHostSkillCacheDir())).toBe(
+			'allow',
+		);
+		// v2 stores each URL under a hashed subdirectory of that root.
+		expect(
+			evaluateExternalDirectory(
+				configured,
+				path.join(getHostSkillCacheDir(), 'a1b2c3'),
+			),
+		).toBe('allow');
+	});
+
+	test('with NO skills.urls the cache is denied — a lane is never MORE permissive', () => {
+		// Nothing under the cache is in Skill.dirs() when no URLs are configured,
+		// so an ordinary session evaluates this path under the base `"*": "ask"`.
+		// An unconditional grant would make the LANE more permissive than an
+		// ordinary session, inverting the property this module preserves.
+		expect(
+			evaluateExternalDirectory(withUrls([]), getHostSkillCacheDir()),
+		).toBe('deny');
+		// The default allowlist (no urls threaded) must behave the same way.
+		expect(act(getHostSkillCacheDir())).toBe('deny');
+	});
+
+	test('a blank or malformed skills.urls entry does not trigger the grant', () => {
+		for (const urls of [[''], ['   '], [null as unknown as string]]) {
+			expect(
+				evaluateExternalDirectory(withUrls(urls), getHostSkillCacheDir()),
+			).toBe('deny');
+		}
+	});
+
+	test('the cache PARENT is denied — it contains host-executed bin/', () => {
+		// Global.Path.bin = join(cache,'bin') (offset 107378747) is created at
+		// startup and executed by the host. external_directory has no read/write
+		// split, so granting the parent would put executable code inside a lane's
+		// write grant. Same reasoning that dropped getPluginCachePaths().
+		const cacheParent = path.dirname(getHostSkillCacheDir());
+		expect(act(cacheParent)).toBe('deny');
+		expect(act(path.join(cacheParent, 'bin'))).toBe('deny');
+		// ...and still denied when the cache root IS granted.
+		const configured = withUrls(['https://example.com/skills/']);
+		expect(evaluateExternalDirectory(configured, cacheParent)).toBe('deny');
+		expect(
+			evaluateExternalDirectory(configured, path.join(cacheParent, 'bin')),
+		).toBe('deny');
+	});
+
 	test('granting the skill roots does NOT re-admit the ~/.opencode tree', () => {
 		// The narrowing that caused the regression must stay in force: the tree
 		// holds the GitLab OAuth auth.json when XDG_DATA_HOME is unset.
@@ -203,8 +271,26 @@ describe('pattern construction', () => {
 		// tests/unit/config/host-path.test.ts for the pinned behaviour.
 		const { dir, cleanup } = createSafeTestDir('lane-pattern-');
 		try {
-			const resolved = path.resolve(dir);
-			expect(laneDirectoryPattern(resolved)).toBe(path.join(resolved, '*'));
+			// The expectation is built with fs.realpathSync.NATIVE, matching the
+			// host's own normalizePath. Two reasons, both found by CI on
+			// windows-latest:
+			//
+			//  - createSafeTestDir canonicalises with plain fs.realpathSync,
+			//    which on Windows does NOT expand an 8.3 short name. The GitHub
+			//    runner's os.tmpdir() is C:\Users\RUNNER~1\..., so the fixture
+			//    keeps the short form while laneDirectoryPattern correctly emits
+			//    the long form C:\Users\runneradmin\...
+			//  - Production is RIGHT to expand it: the host normalises its asked
+			//    patterns with realpathSync.native too, so a short-form rule
+			//    would never match a long-form ask.
+			//
+			// So this asserts the CONTRACT -- natively-canonicalised directory
+			// plus /* -- computed independently of our implementation, rather
+			// than echoing whatever laneDirectoryPattern happens to return.
+			const canonical = fs.realpathSync.native(dir);
+			expect(laneDirectoryPattern(path.resolve(dir))).toBe(
+				path.join(canonical, '*'),
+			);
 		} finally {
 			cleanup();
 		}

--- a/tests/unit/config/lane-permissions.test.ts
+++ b/tests/unit/config/lane-permissions.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Lane `external_directory` allowlist CONSTRUCTION.
+ *
+ * What goes into the allowlist, how each entry's pattern is built, and the
+ * operator-facing advisory text. Rule PRECEDENCE (emission order, user-config
+ * override, host base-allow preservation, config-knob modes) lives in
+ * `lane-permissions-precedence.test.ts`.
+ *
+ * Behavioural assertions run the emitted rules through
+ * `tests/helpers/opencode-permission-model.ts`, a verbatim transcription of the
+ * host's own `Wildcard.match` / `fromConfig` / `merge` / `evaluate`.
+ */
+import { describe, expect, test } from 'bun:test';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { getHostDataDir } from '../../../src/config/cache-paths';
+import { _test_exports } from '../../../src/config/lane-permissions';
+import {
+	asPermission,
+	build,
+	buildLaneAllowlist,
+	buildLaneExternalDirectoryRules,
+	lane,
+} from '../../helpers/lane-permissions-fixture';
+import {
+	evaluateExternalDirectory,
+	hostFromConfig,
+} from '../../helpers/opencode-permission-model';
+
+const { laneDirectoryPattern, renderLanePermissionAdvisory } = _test_exports;
+
+describe('buildLaneAllowlist — justified entries only', () => {
+	const allowlist = buildLaneAllowlist(lane);
+	const dirs = allowlist.map((e) => e.dir);
+
+	test('includes the parent project the lane is a worktree of', () => {
+		expect(dirs).toContain(lane.parentProjectPath);
+	});
+
+	test('includes the lane itself', () => {
+		expect(dirs).toContain(lane.lanePath);
+	});
+
+	test('grants NARROW temp subtrees, never all of os.tmpdir()', () => {
+		// external_directory has no read/write split, so every entry is also a
+		// WRITE grant. Granting the whole shared temp tree would let a lane write
+		// into any other process's temp state.
+		//
+		// NOTE: the `swwt` subtree is deliberately NOT asserted here — it is
+		// win32-only. Asserting it unconditionally passed on a Windows dev box and
+		// failed on the ubuntu CI runner. Its platform-conditional assertion lives
+		// in 'the Windows shortened-lane root is granted only on win32' below.
+		expect(dirs).toContain(path.resolve(path.join(os.tmpdir(), 'opencode')));
+		expect(dirs).not.toContain(path.resolve(os.tmpdir()));
+	});
+
+	test('does NOT grant the plugin cache/install locations (write-grant surface)', () => {
+		// A lane writing its own installed plugin would be executed in-process by
+		// the host on the next load, outside lane teardown.
+		for (const dir of dirs) {
+			expect(
+				dir.includes(`${path.sep}node_modules${path.sep}opencode-swarm`),
+			).toBe(false);
+			expect(dir.includes('opencode-swarm@latest')).toBe(false);
+		}
+	});
+
+	test('includes the user-level .claude/skills root that the field log hung on', () => {
+		expect(dirs).toContain(path.resolve(os.homedir(), '.claude/skills'));
+	});
+
+	test('includes project-relative skill roots for BOTH trees', () => {
+		expect(dirs).toContain(
+			path.resolve(lane.parentProjectPath, '.opencode/skills'),
+		);
+		expect(dirs).toContain(path.resolve(lane.lanePath, '.opencode/skills'));
+	});
+
+	test('re-grants OpenCode plan storage (the host plan agent has a native allow)', () => {
+		// Host Agent.state gives `plan`:
+		//   external_directory: { join(Path.data,'plans','*'): 'allow' }
+		// merged BEFORE the top-level block, so our catch-all would outrank it
+		// and a lane running `plan` would lose its own plan storage.
+		expect(dirs).toContain(path.join(getHostDataDir(), 'plans'));
+	});
+
+	test('does NOT grant the OpenCode data dir itself (auth.json, session storage)', () => {
+		expect(dirs).not.toContain(path.resolve(getHostDataDir()));
+	});
+
+	test('the Windows shortened-lane root is granted only on win32', () => {
+		// shortenWorktreePath fires solely on the Windows path-budget check, so on
+		// POSIX this directory is never created and granting it would be a write
+		// grant into a sticky-bit, world-writable tree for nothing.
+		const swwt = path.join(os.tmpdir(), 'swwt');
+		expect(dirs.includes(swwt)).toBe(process.platform === 'win32');
+	});
+
+	test('every entry carries a non-empty justification', () => {
+		expect(allowlist.length).toBeGreaterThan(0);
+		for (const entry of allowlist) {
+			expect(entry.reason.trim().length).toBeGreaterThan(0);
+			expect(path.isAbsolute(entry.dir)).toBe(true);
+		}
+	});
+
+	test('entries are deduplicated', () => {
+		const key = (d: string) =>
+			process.platform === 'win32' ? d.toLowerCase() : d;
+		expect(new Set(dirs.map(key)).size).toBe(dirs.length);
+	});
+});
+
+describe('regression: skill roots mirror the host glob, not half of it', () => {
+	// Host skill discovery (binary offset 102990880), verbatim:
+	//   bA = ".claude"   xA = ".agents"
+	//   GA = "skills/**/SKILL.md"          <- PLURAL only
+	//   SA = "{skill,skills}/**/SKILL.md"  <- SINGULAR or plural
+	// `.claude`/`.agents` (home + project) use GA; every Config.directories()
+	// entry uses SA. Granting only `skills` for a config root silently denied the
+	// supported singular `skill/` layout — a capability loss introduced when the
+	// whole-tree `~/.opencode` grant was removed.
+	const home = os.homedir();
+	const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(home, '.config');
+	const permission = asPermission(build('scoped_allow'));
+	const act = (dir: string) => evaluateExternalDirectory(permission, dir);
+
+	test.each([
+		['~/.claude/skills/<s>', path.join(home, '.claude', 'skills', 's')],
+		['~/.agents/skills/<s>', path.join(home, '.agents', 'skills', 's')],
+		['~/.opencode/skills/<s>', path.join(home, '.opencode', 'skills', 's')],
+		['~/.opencode/skill/<s>', path.join(home, '.opencode', 'skill', 's')],
+		[
+			'<xdgcfg>/opencode/skill/<s>',
+			path.join(xdgConfig, 'opencode', 'skill', 's'),
+		],
+		[
+			'<proj>/.claude/skills/<s>',
+			path.join(lane.parentProjectPath, '.claude', 'skills', 's'),
+		],
+		[
+			'<proj>/.agents/skills/<s>',
+			path.join(lane.parentProjectPath, '.agents', 'skills', 's'),
+		],
+	])('%s is reachable from a lane', (_label, dir) => {
+		expect(act(dir)).toBe('allow');
+	});
+
+	test('the singular/plural pair is granted for project .opencode too', () => {
+		for (const name of ['skill', 'skills']) {
+			expect(
+				act(path.join(lane.parentProjectPath, '.opencode', name, 's')),
+			).toBe('allow');
+			expect(act(path.join(lane.lanePath, '.opencode', name, 's'))).toBe(
+				'allow',
+			);
+		}
+	});
+
+	test('granting the skill roots does NOT re-admit the ~/.opencode tree', () => {
+		// The narrowing that caused the regression must stay in force: the tree
+		// holds the GitLab OAuth auth.json when XDG_DATA_HOME is unset.
+		expect(act(path.join(home, '.opencode'))).toBe('deny');
+	});
+
+	test('configured skills.paths are granted, with host-identical resolution', () => {
+		// Host resolution (offset 102994011): `~/` expands to $HOME, a relative
+		// path anchors to the instance directory, absolute is used as-is.
+		const withPaths = asPermission(
+			buildLaneExternalDirectoryRules(
+				'scoped_allow',
+				lane,
+				undefined,
+				buildLaneAllowlist(lane, ['~/my-skills', './relative-skills']),
+			)?.rules ?? null,
+		);
+		expect(
+			evaluateExternalDirectory(withPaths, path.join(home, 'my-skills')),
+		).toBe('allow');
+		expect(
+			evaluateExternalDirectory(
+				withPaths,
+				path.join(lane.lanePath, 'relative-skills'),
+			),
+		).toBe('allow');
+	});
+
+	test('a malformed skills config cannot break allowlist construction', () => {
+		for (const bogus of [null, 42, 'nope', [1, 2], [null], ['', '   ']]) {
+			expect(() =>
+				buildLaneAllowlist(lane, bogus as unknown as string[]),
+			).not.toThrow();
+		}
+	});
+});
+
+describe('pattern construction', () => {
+	test('laneDirectoryPattern covers the subtree', () => {
+		const dir = path.resolve('/a/b');
+		expect(laneDirectoryPattern(dir)).toBe(path.join(dir, '*'));
+	});
+
+	test('emitted patterns survive host fromConfig unchanged (no ~ expansion surprises)', () => {
+		const rules = build('scoped_allow');
+		const parsed = hostFromConfig({ external_directory: rules ?? {} });
+		for (const rule of parsed) {
+			expect(rule.permission).toBe('external_directory');
+			// Absolute paths must not have been rewritten by the host's `~`
+			// expansion; only our literal catch-all is non-absolute.
+			if (rule.pattern !== '*') {
+				expect(rule.pattern.startsWith('~')).toBe(false);
+			}
+		}
+	});
+});
+
+describe('operator-facing advisory text', () => {
+	test('names the lane, the parent, the policy and the exact remedy', () => {
+		const text = renderLanePermissionAdvisory(
+			'scoped_allow',
+			lane,
+			buildLaneAllowlist(lane),
+		);
+		expect(text).toContain(lane.lanePath);
+		expect(text).toContain(lane.parentProjectPath);
+		expect(text).toContain('worktree.lane_permissions');
+		expect(text).toContain('external_directory');
+		expect(text).toContain('"off"');
+	});
+
+	test('deny mode says so explicitly', () => {
+		expect(renderLanePermissionAdvisory('deny', lane, [])).toContain(
+			'ALL external directory access is denied',
+		);
+	});
+});

--- a/tests/unit/config/session-create-directory-guardrail.test.ts
+++ b/tests/unit/config/session-create-directory-guardrail.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Phase 4.2 class guardrail — foreign-directory `session.create` call sites.
+ *
+ * ## The defect class
+ *
+ * OpenCode partitions permission state per directory: `Permission.state`,
+ * `Agent.state`, `Plugin.state` and `ToolRegistry.state` are all built through
+ * the same directory-keyed `InstanceState` cache. A session created against a
+ * directory therefore lands in that directory's permission universe.
+ *
+ * The class is NOT "a session created in a directory other than the project
+ * root". A plugin tool's `ctx.directory` is the *invoking instance's*
+ * directory (host `ToolRegistry.state`, ~offset 100775000:
+ * `vi = { ...Ro, ask: ..., directory: W.directory, worktree: W.worktree }`
+ * where `W` is the InstanceState context). So threading `ctx.directory` through
+ * to `session.create` keeps the child in the SAME instance and the SAME
+ * permission universe — that is safe, even when the directory is a worktree.
+ *
+ * The actual defect is:
+ *
+ *   **`query.directory` differs from the `ctx.directory` threaded into that
+ *   call site, without the resulting fresh permission partition being handled.**
+ *
+ * A site like that gets an empty `approved` list (every prior "Allow always" is
+ * forgotten) and a private pending map. If no TUI is attached to that instance,
+ * `Permission.ask` parks on a deferred with no timeout and the work hangs
+ * forever.
+ *
+ * ## What this test enforces
+ *
+ * It maintains an exhaustive inventory of every `session.create(` call site in
+ * `src/` together with the directory expression each one passes. Any new call
+ * site, or any change to an existing site's directory expression, fails until a
+ * human classifies it here. Foreign sites additionally require an explicit
+ * disposition.
+ *
+ * Modelled on `tests/unit/hooks/hook-composition.test.ts`, which uses the same
+ * source-scanning approach to keep the fail-closed hook chain honest.
+ */
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const SRC_ROOT = path.resolve(__dirname, '..', '..', '..', 'src');
+
+type Classification = 'same-instance' | 'foreign';
+
+/**
+ * Allowed dispositions for a FOREIGN site. A foreign site with no disposition
+ * is an unreviewed instance of the defect class.
+ */
+type Disposition =
+	/** The foreign directory is a swarm worktree lane, so the plugin `config`
+	 *  hook running in that instance resolves its permissions up front
+	 *  (`src/config/lane-permissions.ts`). */
+	| 'lane-permission-handled'
+	/** The foreign directory is NOT a swarm worktree lane, so lane policy must
+	 *  not be applied to it (the approved policy requires non-lane sessions to
+	 *  be completely unaffected). Known gap, documented in `note`. */
+	| 'foreign-non-lane-documented';
+
+interface DeclaredSite {
+	file: string;
+	/** Directory expression exactly as the scanner normalises it. */
+	directoryExpr: string;
+	classification: Classification;
+	disposition?: Disposition;
+	note: string;
+}
+
+/**
+ * THE INVENTORY. Every `session.create(` in `src/` must appear here.
+ *
+ * To add a site: run this test, copy the reported `file|expr` pair, and add an
+ * entry with an honest classification. If your new site passes a directory that
+ * differs from the `ctx.directory` threaded into it, it is `foreign` and needs
+ * a disposition — do not classify it `same-instance` to make the test pass.
+ */
+const DECLARED_SITES: DeclaredSite[] = [
+	{
+		file: 'src/evaluation/ephemeral-agent-dispatcher.ts',
+		directoryExpr: 'request.directory',
+		classification: 'foreign',
+		disposition: 'foreign-non-lane-documented',
+		note:
+			'Two production chains, both under os.tmpdir() and neither a swarm worktree lane: ' +
+			'src/evaluation/runner.ts:750 passes args.isolatedRoot (a subpath of a disposable ' +
+			'worktree created at path.join(os.tmpdir(), WORKTREE_PARENT) by ' +
+			'src/evaluation/disposable-worktree.ts), and src/evaluation/gate-audit.ts:480 passes ' +
+			'a mkdtempSync root under os.tmpdir(). Both get a fresh permission partition and can ' +
+			'hang the same way. NOT covered by lane-permission handling: resolveLaneContext ' +
+			'requires a swarm-OWNED linked git worktree (a `swarm/`/`swarm-lane/` branch, or the ' +
+			'.swarm-worktrees path fallback) and neither temp root is one, and the approved ' +
+			'policy explicitly forbids applying lane policy to non-lane sessions. Known gap.',
+	},
+	{
+		file: 'src/full-auto/oversight.ts',
+		directoryExpr: 'input.directory',
+		classification: 'same-instance',
+		note: 'Closes over ctx.directory captured at plugin init (src/index.ts:1202-1204).',
+	},
+	{
+		file: 'src/hooks/curator-llm-factory.ts',
+		directoryExpr: 'directory',
+		classification: 'same-instance',
+		note: 'The `directory` parameter is the caller tool/hook ctx.directory, passed through unchanged.',
+	},
+	{
+		file: 'src/hooks/delegation-gate/worktree-isolation.ts',
+		directoryExpr: 'provisionResult.worktreePath',
+		classification: 'foreign',
+		disposition: 'lane-permission-handled',
+		note:
+			'PRIMARY FIX SITE. Creates the worktree-lane session that started this defect. ' +
+			'provisionWorktree builds the path under resolveWorktreeBaseDir (.swarm-worktrees), ' +
+			'so the lane instance is recognised by src/config/lane-context.ts and its ' +
+			'permissions are pre-resolved by the plugin config hook.',
+	},
+	{
+		file: 'src/hooks/full-auto-intercept.ts',
+		directoryExpr: 'directory',
+		classification: 'same-instance',
+		note: 'Closes over ctx.directory captured at plugin init (src/index.ts:1184-1186).',
+	},
+	{
+		file: 'src/hooks/skill-improver-llm-factory.ts',
+		directoryExpr: 'directory',
+		classification: 'same-instance',
+		note: 'The `directory` parameter is the caller tool/command ctx.directory.',
+	},
+	{
+		file: 'src/mutation/generator.ts',
+		directoryExpr: 'directory',
+		classification: 'same-instance',
+		note: 'Resolves from the generate_mutants tool ctx (ctx.directory ?? process.cwd()).',
+	},
+	{
+		file: 'src/tools/dispatch-lanes.ts',
+		directoryExpr: 'HELPER buildLaneSessionCreateArgs(args.directory)',
+		classification: 'same-instance',
+		note:
+			'dispatch_lanes_async tool ctx.directory. buildLaneSessionCreateArgs ' +
+			'(src/tools/dispatch-lanes.ts:2510) returns query.directory unchanged.',
+	},
+	{
+		file: 'src/tools/dispatch-lanes.ts',
+		directoryExpr: 'HELPER buildLaneSessionCreateArgs(directory)',
+		classification: 'same-instance',
+		note: 'dispatch_lanes tool ctx.directory, passed through buildLaneSessionCreateArgs unchanged.',
+	},
+	{
+		file: 'src/turbo/lean/integration.ts',
+		directoryExpr: 'directory',
+		classification: 'same-instance',
+		note:
+			'dispatchPhaseCritic parameter — same-instance when reached. NOTE it currently has ' +
+			'zero production callers, so the site is unreachable rather than unsafe. It is NOT ' +
+			'dead code to delete: writeCriticEvidence (integration.ts:411, reachable only via ' +
+			'dispatchPhaseCritic) is the ONLY writer of .swarm/evidence/{phase}/lean-turbo-critic.json, ' +
+			'which src/turbo/lean/phase-ready.ts:675 reads to satisfy the phase_critic gate — a ' +
+			'flag that defaults to true (src/config/schema.ts) and is documented in ' +
+			'docs/configuration.md and docs/modes.md. This is an UNWIRED FEATURE (the missing ' +
+			'lean_turbo_critic tool registration, mirroring lean_turbo_review) and needs wiring ' +
+			'or an explicit product decision to remove the flag and docs too — not a silent delete.',
+	},
+	{
+		file: 'src/turbo/lean/runner.ts',
+		directoryExpr: 'effectiveDirectory',
+		classification: 'foreign',
+		disposition: 'lane-permission-handled',
+		note:
+			'PRIMARY FIX SITE. effectiveDirectory = worktreeDirectory ?? this._directory; ' +
+			'worktreeDirectory is set at src/turbo/lean/runner.ts:1087/1124 from ' +
+			'provisionWorktree(...).worktreePath. The lane is NOT necessarily under ' +
+			'.swarm-worktrees (a worktree_dir override or the Windows path-budget fallback ' +
+			'place it elsewhere), so recognisability rests on the BRANCH grammar, which the ' +
+			'executable assertions below verify rather than assert by annotation. The ' +
+			'fallback branch is same-instance.',
+	},
+];
+
+import {
+	buildSwarmBranchName,
+	matchSwarmLaneBranch,
+} from '../../../src/config/swarm-branch';
+import {
+	discoverSites,
+	stripCommentsWithState,
+	tokenizerFailures,
+} from '../../helpers/session-create-scanner';
+
+const identity = (s: { file: string; directoryExpr: string }): string =>
+	`${s.file}|${s.directoryExpr}`;
+
+const HOWTO = [
+	'',
+	'A `session.create(` call site in src/ is not declared in DECLARED_SITES,',
+	'or its directory expression changed.',
+	'',
+	'WHY THIS MATTERS: OpenCode partitions permission state per directory.',
+	'Creating a session against a directory that differs from the ctx.directory',
+	'threaded into the call site gives that session an EMPTY `approved` list and',
+	'a private pending map. If no TUI is attached to that instance, an',
+	'`external_directory` prompt raised there can never be answered and the work',
+	'hangs forever (Permission.ask awaits its deferred with no timeout).',
+	'',
+	'WHAT TO DO:',
+	' 1. Trace the directory expression to its origin.',
+	' 2. If it is the same ctx.directory threaded into this call site, declare it',
+	"    `classification: 'same-instance'` with a note naming the origin.",
+	" 3. If it differs, it is `classification: 'foreign'` and needs a disposition:",
+	"      'lane-permission-handled'        - it is a .swarm-worktrees lane, so",
+	'                                         src/config/lane-permissions.ts',
+	'                                         pre-resolves its permissions.',
+	"      'foreign-non-lane-documented'    - it is not a lane; record the gap.",
+	' 4. Do NOT classify a foreign site as same-instance to silence this test.',
+	'',
+].join('\n');
+
+describe('Phase 4.2 guardrail: session.create foreign-directory inventory', () => {
+	const discovered = discoverSites(SRC_ROOT);
+
+	test('every discovered call site is declared (and nothing declared is stale)', () => {
+		const discoveredIds = discovered.map(identity).sort();
+		const declaredIds = DECLARED_SITES.map(identity).sort();
+		const undeclared = discovered.filter(
+			(s) => !declaredIds.includes(identity(s)),
+		);
+		const stale = DECLARED_SITES.filter(
+			(s) => !discoveredIds.includes(identity(s)),
+		);
+		const detail = [
+			HOWTO,
+			undeclared.length
+				? `UNDECLARED:\n${undeclared.map((s) => `  ${s.file}:${s.line} | ${s.directoryExpr}`).join('\n')}`
+				: '',
+			stale.length
+				? `STALE (declared but no longer found — remove the entry):\n${stale.map((s) => `  ${identity(s)}`).join('\n')}`
+				: '',
+		]
+			.filter(Boolean)
+			.join('\n');
+		expect({
+			undeclared: undeclared.map(identity),
+			stale: stale.map(identity),
+			detail,
+		}).toEqual({ undeclared: [], stale: [], detail });
+	});
+
+	test('the scanner actually finds call sites (it cannot pass by finding nothing)', () => {
+		expect(discovered.length).toBeGreaterThanOrEqual(DECLARED_SITES.length);
+		expect(discovered.length).toBeGreaterThan(5);
+	});
+
+	test('the tokenizer parses every source file to completion (no silent blindness)', () => {
+		// A stripper that loses track (e.g. treats `/*` inside a string literal as
+		// a block comment) blanks the rest of that file and silently stops
+		// finding call sites in it. The count assertion above cannot detect
+		// PARTIAL blindness, so assert the terminal state per file instead.
+		expect(tokenizerFailures).toEqual([]);
+	});
+
+	test('regression: a `/*` inside a string literal does not blind the scanner', () => {
+		// The exact construct that defeated the previous 3-state stripper. Seven
+		// files in src/ contain one, including this feature's own
+		// src/config/lane-permissions.ts.
+		const sample = [
+			"const glob = '**/*.ts';",
+			'const other = "a /* not a comment";',
+			'const t = `tpl /* still not */ ${x} end`;',
+			'const re = /[/*]/g;',
+			'await client.session.create({ query: { directory: laterDir } });',
+		].join('\n');
+		const stripped = stripCommentsWithState(sample);
+		expect(stripped.state).toBe('code');
+		expect(stripped.source).toContain('session.create(');
+		expect(stripped.source).toContain('laterDir');
+	});
+
+	test('regression: real comments are still blanked', () => {
+		const sample = [
+			'/* await client.session.create({ query: { directory: ghost } }); */',
+			'// await client.session.create({ query: { directory: ghost2 } });',
+			'const real = 1;',
+		].join('\n');
+		const stripped = stripCommentsWithState(sample);
+		expect(stripped.state).toBe('code');
+		expect(stripped.source).not.toContain('session.create(');
+		expect(stripped.source).toContain('const real = 1;');
+		// Line numbering must survive blanking.
+		expect(stripped.source.split('\n').length).toBe(3);
+	});
+
+	test('no call site has an unrecognised directory expression', () => {
+		const bad = discovered.filter((s) => s.directoryExpr === 'UNRECOGNISED');
+		expect(bad.map((s) => `${s.file}:${s.line}`)).toEqual([]);
+	});
+
+	test('every FOREIGN site carries an explicit disposition', () => {
+		const missing = DECLARED_SITES.filter(
+			(s) => s.classification === 'foreign' && !s.disposition,
+		);
+		expect(missing.map((s) => s.file)).toEqual([]);
+	});
+
+	test('every declared site carries a non-trivial note', () => {
+		for (const site of DECLARED_SITES) {
+			expect(site.note.trim().length).toBeGreaterThan(20);
+		}
+	});
+
+	test('the two known worktree-lane sites are covered by lane-permission handling', () => {
+		const covered = DECLARED_SITES.filter(
+			(s) => s.disposition === 'lane-permission-handled',
+		).map((s) => s.file);
+		expect(covered).toContain(
+			'src/hooks/delegation-gate/worktree-isolation.ts',
+		);
+		expect(covered).toContain('src/turbo/lean/runner.ts');
+	});
+
+	test('EXECUTABLE: every branch a lane site can provision IS recognisable', () => {
+		// The disposition string is an annotation; annotations drift. This asserts
+		// the PROPERTY the disposition claims — that a lane created through the
+		// provisioning boundary is one lane detection can actually recognise —
+		// across every naming style provisionWorktree can emit.
+		//
+		// This is the assertion that would have caught the unvalidated-sessionID
+		// hole: `ses-run-1` passes the host's `isStartsWith("ses")` brand but
+		// yields `swarm-lane/ses-run-1/lane-1`, which the recogniser rejects.
+		const realSessionId = 'ses_0410b724cffeApmZIOs5VH9XsN';
+		for (const purpose of ['lane', 'review', 'evaluation']) {
+			for (const legacy of [false, true]) {
+				const branch = buildSwarmBranchName(
+					realSessionId,
+					'1.1',
+					purpose,
+					legacy,
+				);
+				expect(matchSwarmLaneBranch(branch)).toBeDefined();
+			}
+		}
+	});
+
+	test('EXECUTABLE: provisioning refuses any sessionID it could not later recognise', () => {
+		// The structural guard in provisionWorktree and the recogniser used by
+		// lane detection must be the SAME rule, with no gap between them.
+		for (const sessionId of ['ses-run-1', 'phase-3', 'session123', 'ses_']) {
+			const branch = buildSwarmBranchName(sessionId, 'lane-1', 'lane', false);
+			expect(matchSwarmLaneBranch(branch)).toBeUndefined();
+		}
+		const guardSource = fs.readFileSync(
+			path.join(SRC_ROOT, 'worktree', 'core.ts'),
+			'utf-8',
+		);
+		// provisionWorktree must hard-fail, not warn, on an unrecognisable branch.
+		expect(guardSource).toMatch(/if \(!matchSwarmLaneBranch\(branchName\)\)/);
+		expect(guardSource).toContain('Refusing to provision worktree');
+	});
+
+	test('lane-permission handling actually exists and is wired into the config hook', () => {
+		// A disposition of 'lane-permission-handled' is only meaningful if the
+		// handler is real and reachable from the plugin entry point.
+		const indexSource = fs.readFileSync(
+			path.join(SRC_ROOT, 'index.ts'),
+			'utf-8',
+		);
+		expect(indexSource).toContain('applyLanePermissions');
+		expect(indexSource).toMatch(
+			/applyLanePermissions\(\s*opencodeConfig,\s*ctx\.directory,/,
+		);
+		expect(
+			fs.existsSync(path.join(SRC_ROOT, 'config', 'lane-permissions.ts')),
+		).toBe(true);
+		expect(
+			fs.existsSync(path.join(SRC_ROOT, 'config', 'lane-context.ts')),
+		).toBe(true);
+	});
+});

--- a/tests/unit/config/swarm-branch.test.ts
+++ b/tests/unit/config/swarm-branch.test.ts
@@ -1,0 +1,236 @@
+/**
+ * The swarm worktree branch grammar.
+ *
+ * This grammar is a SECURITY boundary, not a convenience. `matchSwarmLaneBranch`
+ * is the ownership signal for lane detection, and a false positive is worse
+ * than the bug the lane subsystem fixes: an ordinary interactive session
+ * misclassified as a lane gets `external_directory: {"*":"deny", …}` injected,
+ * and the host's `Permission.ask` short-circuits on deny BEFORE creating a
+ * deferred —
+ *
+ *   if (W.action === "deny") return yield* new U.DeniedError({ … });
+ *
+ * — so no prompt is raised and the user cannot recover with "Allow always".
+ *
+ * Hence two suites: a round-trip property test over the real producer, and a
+ * negative corpus of plausible human-authored branch names.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+	_test_exports,
+	buildSwarmBranchName,
+	isSwarmSessionId,
+	matchSwarmLaneBranch,
+} from '../../../src/config/swarm-branch';
+import { makeWorktreeBranchName } from '../../../src/worktree/core';
+
+const { SWARM_WORKTREE_BRANCH_PREFIXES } = _test_exports;
+
+/**
+ * Faithful replica of OpenCode's session-id generator, so the corpus is driven
+ * by the shape production actually emits rather than by strings hand-written to
+ * satisfy our own regex (which would make the property test tautological).
+ *
+ * Host source (offsets ~106619050 and ~151487303 — two independent generators
+ * that agree):
+ *   `prefix + "_" + <6 bytes as hex> + <base62 of length V-12>`, with `V = 26`.
+ * So the body is 12 hex chars + 14 base62 chars = 26, giving a 30-char id.
+ * The base62 alphabet is
+ * "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".
+ */
+const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const ID_BODY_LENGTH = 26;
+
+function generateHostSessionId(seed: number): string {
+	const millis = 1_700_000_000_000 + seed;
+	let value = BigInt(millis) * BigInt(4096) + BigInt(seed % 4096);
+	const bytes = new Uint8Array(6);
+	for (let i = 0; i < 6; i += 1) {
+		bytes[i] = Number((value >> BigInt(40 - 8 * i)) & BigInt(255));
+	}
+	let hex = '';
+	for (const b of bytes) hex += b.toString(16).padStart(2, '0');
+	let tail = '';
+	for (let i = 0; i < ID_BODY_LENGTH - 12; i += 1) {
+		value = value * BigInt(31) + BigInt(i + seed + 7);
+		tail += BASE62[Number(value % BigInt(62))];
+	}
+	return `ses_${hex}${tail}`;
+}
+
+const GENERATED_IDS = Array.from({ length: 12 }, (_, i) =>
+	generateHostSessionId(i * 977 + 3),
+);
+
+const SESSION_IDS = [
+	...GENERATED_IDS,
+	// A real id observed in the field log for this defect.
+	'ses_0410b724cffeApmZIOs5VH9XsN',
+	// Boundary lengths: the shortest body the grammar can accept, and a body
+	// longer than the generator emits (defensive against a future length bump).
+	'ses_a',
+	`ses_${'a'.repeat(ID_BODY_LENGTH * 2)}`,
+	// Alphabet extremes actually reachable from the base62 table.
+	`ses_${BASE62[0].repeat(ID_BODY_LENGTH)}`,
+	`ses_${BASE62[BASE62.length - 1].repeat(ID_BODY_LENGTH)}`,
+];
+const IDS = ['1.1', '2.10', 'task-7', 'T1', 'a_b', '1.1.1', 'lane.3-b'];
+const PURPOSES = ['lane', 'review', 'evaluation', 'pr-workflow'];
+const STYLES = ['purpose', 'legacy-lane'] as const;
+
+describe('the corpus models the real generator (not the regex)', () => {
+	test('generated ids match the host id shape: ses_ + 12 hex + 14 base62', () => {
+		for (const id of GENERATED_IDS) {
+			expect(id).toMatch(/^ses_[0-9a-f]{12}[0-9A-Za-z]{14}$/);
+			expect(id.length).toBe(4 + ID_BODY_LENGTH);
+		}
+	});
+
+	test('the generated ids are distinct (the corpus is not one value repeated)', () => {
+		expect(new Set(GENERATED_IDS).size).toBe(GENERATED_IDS.length);
+	});
+
+	test('a value that passes the HOST brand but not our grammar is rejected', () => {
+		// The host's SessionID brand is only isStartsWith("ses"), so these reach
+		// provisionWorktree intact. This is the exact HIGH-2 window.
+		for (const id of ['ses-run-1', 'session123', 'sesX', 'ses.1']) {
+			expect(id.startsWith('ses')).toBe(true);
+			expect(isSwarmSessionId(id)).toBe(false);
+			expect(
+				matchSwarmLaneBranch(buildSwarmBranchName(id, '1.1', 'lane', false)),
+			).toBeUndefined();
+		}
+	});
+
+	test('every generated id is accepted by the shared predicate', () => {
+		for (const id of SESSION_IDS) expect(isSwarmSessionId(id)).toBe(true);
+	});
+});
+
+describe('round-trip property: every branch the producer emits is recognised', () => {
+	// Drives the REAL producer (`makeWorktreeBranchName`), not a copy, so the
+	// grammar cannot drift from what provisionWorktree actually creates.
+	const cases: Array<{
+		sessionId: string;
+		id: string;
+		purpose: string;
+		branchStyle: (typeof STYLES)[number];
+	}> = [];
+	for (const sessionId of SESSION_IDS) {
+		for (const id of IDS) {
+			for (const purpose of PURPOSES) {
+				for (const branchStyle of STYLES) {
+					cases.push({ sessionId, id, purpose, branchStyle });
+				}
+			}
+		}
+	}
+
+	test(`matches all ${cases.length} producer outputs`, () => {
+		const unmatched: string[] = [];
+		for (const c of cases) {
+			const branch = makeWorktreeBranchName(c.sessionId, c.id, {
+				purpose: c.purpose as never,
+				branchStyle: c.branchStyle,
+			});
+			if (matchSwarmLaneBranch(branch) === undefined) unmatched.push(branch);
+		}
+		expect(unmatched).toEqual([]);
+	});
+
+	test('round-trips the parsed parts back to the original inputs', () => {
+		for (const c of cases) {
+			const branch = makeWorktreeBranchName(c.sessionId, c.id, {
+				purpose: c.purpose as never,
+				branchStyle: c.branchStyle,
+			});
+			const parsed = matchSwarmLaneBranch(branch);
+			expect(parsed?.sessionId).toBe(c.sessionId);
+			expect(parsed?.id).toBe(c.id);
+			// legacy-lane encodes no purpose, so it always reports 'lane'.
+			const legacy = c.branchStyle === 'legacy-lane' && c.purpose === 'lane';
+			expect(parsed?.purpose).toBe(legacy ? 'lane' : c.purpose);
+			expect(parsed?.style).toBe(legacy ? 'legacy-lane' : 'purpose');
+		}
+	});
+
+	test('the shared builder and the worktree producer agree exactly', () => {
+		for (const c of cases) {
+			const viaCore = makeWorktreeBranchName(c.sessionId, c.id, {
+				purpose: c.purpose as never,
+				branchStyle: c.branchStyle,
+			});
+			const viaGrammar = buildSwarmBranchName(
+				c.sessionId,
+				c.id,
+				c.purpose,
+				c.branchStyle === 'legacy-lane' && c.purpose === 'lane',
+			);
+			expect(viaCore).toBe(viaGrammar);
+		}
+	});
+
+	test('both documented prefixes are actually exercised', () => {
+		const emitted = new Set(
+			cases.map(
+				(c) =>
+					makeWorktreeBranchName(c.sessionId, c.id, {
+						purpose: c.purpose as never,
+						branchStyle: c.branchStyle,
+					}).split('/')[0],
+			),
+		);
+		for (const prefix of SWARM_WORKTREE_BRANCH_PREFIXES) {
+			expect(emitted).toContain(prefix.replace(/\/$/, ''));
+		}
+	});
+});
+
+describe('negative corpus: plausible human branches must NOT be lanes', () => {
+	// Every one of these matched under the previous bare-prefix check.
+	test.each([
+		// The reproduced HIGH-1 case: `git worktree add -b swarm/my-own-experiment`
+		['swarm/my-own-experiment'],
+		['swarm/feature/foo'],
+		['swarm-lane/wip'],
+		['swarm/lane/notasession/1.1'],
+		['swarmy/x'],
+		['swarm/lane/ses_x/1.1-extra-segment/deep'],
+		// Further shapes in the same family.
+		['swarm'],
+		['swarm/'],
+		['swarm-lane'],
+		['swarm-lane/'],
+		['swarm/lane'],
+		['swarm/lane/ses_abc'],
+		['swarm-lane/ses_abc'],
+		['swarm/lane/ses_abc/1.1/'],
+		// `session123` is a human-plausible branch AND the exact shape an
+		// unvalidated tool argument produces — rejected either way.
+		['swarm/lane/session123/1.1'],
+		['swarm/lane/SES_abc/1.1'],
+		['swarm/lane/ses_/1.1'],
+		['swarm/lane/ses_ab-cd/1.1'],
+		['swarm-lanes/ses_abc/1.1'],
+		['feature/swarm/lane/ses_abc/1.1'],
+		['swarm//ses_abc/1.1'],
+		['swarm/lane//1.1'],
+		['swarm/./ses_abc/1.1'],
+		['swarm/lane/ses_abc/..'],
+		['swarm/../ses_abc/1.1'],
+	])('%s is not recognised', (branch) => {
+		expect(matchSwarmLaneBranch(branch)).toBeUndefined();
+	});
+
+	test.each([
+		['empty string', ''],
+		['not a string', 42],
+		['null', null],
+		['undefined', undefined],
+	])('%s returns undefined without throwing', (_label, input) => {
+		expect(() =>
+			matchSwarmLaneBranch(input as unknown as string),
+		).not.toThrow();
+		expect(matchSwarmLaneBranch(input as unknown as string)).toBeUndefined();
+	});
+});

--- a/tests/unit/hooks/delegation-gate-doc-only-evidence.test.ts
+++ b/tests/unit/hooks/delegation-gate-doc-only-evidence.test.ts
@@ -81,7 +81,7 @@ describe('delegation gate doc-only durable evidence', () => {
 			'\n.swarm/\n',
 		);
 		fs.mkdirSync(path.join(directory, '.swarm'), { recursive: true });
-		startAgentSession('architect-session', 'architect');
+		startAgentSession('ses_architectSession', 'architect');
 	});
 
 	afterEach(() => {
@@ -107,7 +107,7 @@ describe('delegation gate doc-only durable evidence', () => {
 				'TASK: 1.1\nImplement the approved task.\nACCEPTANCE: task complete and covered by tests',
 		};
 		await hook.toolBefore(
-			{ tool: 'Task', sessionID: 'architect-session', callID: 'coder-call' },
+			{ tool: 'Task', sessionID: 'ses_architectSession', callID: 'coder-call' },
 			{ args },
 		);
 		for (const relativePath of actualFiles) {
@@ -118,14 +118,14 @@ describe('delegation gate doc-only durable evidence', () => {
 		await hook.toolAfter(
 			{
 				tool: 'Task',
-				sessionID: 'architect-session',
+				sessionID: 'ses_architectSession',
 				callID: 'coder-call',
 				args,
 			},
 			{},
 		);
 		swarmState.agentSessions
-			.get('architect-session')
+			.get('ses_architectSession')
 			?.taskWorkflowStates?.set('1.1', 'coder_delegated');
 		return hook;
 	}
@@ -138,7 +138,7 @@ describe('delegation gate doc-only durable evidence', () => {
 		await hook.toolAfter(
 			{
 				tool: 'Task',
-				sessionID: 'architect-session',
+				sessionID: 'ses_architectSession',
 				callID: 'reviewer-call',
 				args: { subagent_type: 'reviewer', task_id: '1.1' },
 			},
@@ -148,7 +148,7 @@ describe('delegation gate doc-only durable evidence', () => {
 		expect(evidence?.gates.reviewer).toBeDefined();
 		expect(
 			swarmState.agentSessions
-				.get('architect-session')
+				.get('ses_architectSession')
 				?.taskWorkflowStates?.get('1.1'),
 		).toBe('tests_run');
 		expect(checkReviewerGate('1.1', directory).blocked).toBe(false);
@@ -160,7 +160,7 @@ describe('delegation gate doc-only durable evidence', () => {
 		await hook.toolAfter(
 			{
 				tool: 'update_task_status',
-				sessionID: 'architect-session',
+				sessionID: 'ses_architectSession',
 				callID: 'completion-call',
 				args: { task_id: '1.1', status: 'completed' },
 			},
@@ -168,7 +168,7 @@ describe('delegation gate doc-only durable evidence', () => {
 		);
 		expect(
 			swarmState.agentSessions
-				.get('architect-session')
+				.get('ses_architectSession')
 				?.taskWorkflowStates?.get('1.1'),
 		).toBe('complete');
 
@@ -208,7 +208,7 @@ describe('delegation gate doc-only durable evidence', () => {
 			await hook.toolBefore(
 				{
 					tool: 'Task',
-					sessionID: 'architect-session',
+					sessionID: 'ses_architectSession',
 					callID: 'non-doc-coder-call',
 				},
 				{
@@ -269,7 +269,7 @@ describe('delegation gate doc-only durable evidence', () => {
 				await hook.toolBefore(
 					{
 						tool: 'Task',
-						sessionID: 'architect-session',
+						sessionID: 'ses_architectSession',
 						callID: 'worktree-doc-coder-call',
 					},
 					{ args },
@@ -289,7 +289,7 @@ describe('delegation gate doc-only durable evidence', () => {
 				await hook.toolAfter(
 					{
 						tool: 'Task',
-						sessionID: 'architect-session',
+						sessionID: 'ses_architectSession',
 						callID: 'worktree-doc-coder-call',
 						args,
 					},

--- a/tests/unit/hooks/delegation-gate-worktree-isolation.resolution.test.ts
+++ b/tests/unit/hooks/delegation-gate-worktree-isolation.resolution.test.ts
@@ -108,7 +108,7 @@ async function callToolBefore(
 	args: Record<string, unknown>,
 ): Promise<void> {
 	await hook.toolBefore(
-		{ tool, sessionID, callID: `call-${Date.now()}` },
+		{ tool, sessionID, callID: `call-${crypto.randomUUID()}` },
 		{ args },
 	);
 }
@@ -271,7 +271,7 @@ describe('delegation-gate: worktree isolation', () => {
 		});
 
 		try {
-			const session = ensureAgentSession('sc104-session');
+			const session = ensureAgentSession('ses_sc104Session');
 			session.pendingAdvisoryMessages = [];
 
 			await precreateStandardWorktreeSession({
@@ -283,7 +283,7 @@ describe('delegation-gate: worktree isolation', () => {
 					},
 				} as any,
 				directory: tempDir,
-				parentSessionID: 'sc104-session',
+				parentSessionID: 'ses_sc104Session',
 				callID: 'call-sc104',
 				taskId: 'task-sc104',
 				description: 'run tests and build the feature',
@@ -326,7 +326,7 @@ describe('delegation-gate: worktree isolation', () => {
 		});
 
 		try {
-			const session = ensureAgentSession('sc104-neg-session');
+			const session = ensureAgentSession('ses_sc104NegSession');
 			session.pendingAdvisoryMessages = [];
 
 			await precreateStandardWorktreeSession({
@@ -338,7 +338,7 @@ describe('delegation-gate: worktree isolation', () => {
 					},
 				} as any,
 				directory: tempDir,
-				parentSessionID: 'sc104-neg-session',
+				parentSessionID: 'ses_sc104NegSession',
 				callID: 'call-sc104-neg',
 				taskId: 'task-sc104-neg',
 				// Description has NO test/build/lint/check keywords
@@ -389,7 +389,7 @@ describe('delegation-gate: worktree isolation', () => {
 			await precreateStandardWorktreeSession({
 				config: { worktree: { policy: 'auto' } } as any,
 				directory: tempDir,
-				parentSessionID: 'scopefwd-session',
+				parentSessionID: 'ses_scopefwdSession',
 				callID: 'call-scopefwd',
 				taskId: 'task-scopefwd',
 				outputArgs: {},
@@ -475,7 +475,7 @@ describe('delegation-gate: worktree isolation', () => {
 				await precreateStandardWorktreeSession({
 					config: { worktree: { policy: 'auto' } } as any,
 					directory: realGitDir,
-					parentSessionID: 'e2e-scope-session',
+					parentSessionID: 'ses_e2eScopeSession',
 					callID: 'call-e2e-scope',
 					taskId: 'e2e-1.2',
 					outputArgs: {},

--- a/tests/unit/scope/scope-durability-fr102.test.ts
+++ b/tests/unit/scope/scope-durability-fr102.test.ts
@@ -129,7 +129,7 @@ describe('FR-102 SC-105: precreateStandardWorktreeSession without scope does NOT
 	test('precreateStandardWorktreeSession without scope option does not materialize a scope file', async () => {
 		swarmState.opencodeClient = {
 			session: {
-				create: async () => ({ data: { id: 'sess-no-scope' } }),
+				create: async () => ({ data: { id: 'ses_noScope' } }),
 			},
 		} as any;
 
@@ -146,7 +146,7 @@ describe('FR-102 SC-105: precreateStandardWorktreeSession without scope does NOT
 		await precreateStandardWorktreeSession({
 			config: { worktree: { policy: 'auto' } } as any,
 			directory: gitDir,
-			parentSessionID: 'neg-session',
+			parentSessionID: 'ses_negSession',
 			callID: 'call-neg-scope',
 			taskId: 'task-neg',
 			outputArgs: {},
@@ -219,7 +219,7 @@ describe('FR-102 SC-105: lean turbo provisionWorktree creates scope file in lane
 		const result = await provisionLeanWorktree(
 			gitDir,
 			'lane-lean',
-			'sess-lean',
+			'ses_lean',
 			{
 				worktree_dir: undefined,
 				merge_strategy: 'merge',
@@ -252,7 +252,7 @@ describe('FR-102 SC-105: lean turbo provisionWorktree creates scope file in lane
 		const result = await provisionLeanWorktree(
 			gitDir,
 			'lane-lean-no-scope',
-			'sess-lean-no-scope',
+			'ses_leanNoScope',
 			{
 				worktree_dir: undefined,
 				merge_strategy: 'merge',
@@ -353,7 +353,7 @@ describe('FR-102 SC-105: scope write is contained within lane — symlink bounda
 		const taskId = '5.5';
 		const scopeFiles = ['src/safe.ts'];
 
-		const result = await provisionWorktree(gitDir, 'lane-safe', 'sess-safe', {
+		const result = await provisionWorktree(gitDir, 'lane-safe', 'ses_safe', {
 			purpose: 'lane',
 			scope: { taskId, files: scopeFiles },
 		});
@@ -453,7 +453,7 @@ describe('FR-102: AGENTS.md invariant 4 — materialized scope file is gitignore
 		const taskId = '4.5';
 		const scopeFiles = ['src/gi.ts'];
 
-		const result = await provisionWorktree(gitDir, 'lane-gi', 'sess-gi', {
+		const result = await provisionWorktree(gitDir, 'lane-gi', 'ses_gi', {
 			purpose: 'lane',
 			scope: { taskId, files: scopeFiles },
 		});

--- a/tests/unit/scope/scope-persistence.test.ts
+++ b/tests/unit/scope/scope-persistence.test.ts
@@ -109,15 +109,10 @@ describe('FR-102: scope materialization into lane worktrees (SC-105)', () => {
 		const taskId = '1.2';
 		const scopeFiles = ['src/foo.ts', 'src/bar.ts'];
 
-		const result = await provisionWorktree(
-			dirs.hostDir,
-			'lane-42',
-			'sess-abc',
-			{
-				purpose: 'lane',
-				scope: { taskId, files: scopeFiles },
-			},
-		);
+		const result = await provisionWorktree(dirs.hostDir, 'lane-42', 'ses_abc', {
+			purpose: 'lane',
+			scope: { taskId, files: scopeFiles },
+		});
 
 		if ('error' in result) {
 			throw new Error(`provision failed: ${result.error}`);
@@ -141,15 +136,10 @@ describe('FR-102: scope materialization into lane worktrees (SC-105)', () => {
 		const taskId = '1.2';
 		const scopeFiles = ['src/a.ts', 'src/b.ts'];
 
-		const result = await provisionWorktree(
-			dirs.hostDir,
-			'lane-43',
-			'sess-def',
-			{
-				purpose: 'lane',
-				scope: { taskId, files: scopeFiles },
-			},
-		);
+		const result = await provisionWorktree(dirs.hostDir, 'lane-43', 'ses_def', {
+			purpose: 'lane',
+			scope: { taskId, files: scopeFiles },
+		});
 		if ('error' in result) throw new Error(result.error);
 
 		const lanePath = result.worktreePath;
@@ -169,15 +159,10 @@ describe('FR-102: scope materialization into lane worktrees (SC-105)', () => {
 		const taskId = '1.2';
 		const scopeFiles = ['src/x.ts'];
 
-		const result = await provisionWorktree(
-			dirs.hostDir,
-			'lane-44',
-			'sess-ghi',
-			{
-				purpose: 'lane',
-				scope: { taskId, files: scopeFiles },
-			},
-		);
+		const result = await provisionWorktree(dirs.hostDir, 'lane-44', 'ses_ghi', {
+			purpose: 'lane',
+			scope: { taskId, files: scopeFiles },
+		});
 		if ('error' in result) throw new Error(result.error);
 
 		const lanePath = result.worktreePath;
@@ -250,7 +235,7 @@ describe('FR-102: restart-mid-dispatch durability (SC-106)', () => {
 		const provisionResult = await provisionWorktree(
 			dirs.hostDir,
 			'lane-restart',
-			'sess-restart',
+			'ses_restart',
 			{
 				purpose: 'lane',
 				scope: { taskId, files: scopeFiles },

--- a/tests/unit/tools/epic-run-phase.test.ts
+++ b/tests/unit/tools/epic-run-phase.test.ts
@@ -639,10 +639,10 @@ describe('epic_decide_phase tool — ctx.sessionID precedence (Fix B)', () => {
 			) => Promise<unknown>;
 		};
 		await def.execute(
-			{ phase: 1, sessionID: 'default' },
-			{ sessionID: 'real-session-abc123', directory: '/fake' },
+			{ phase: 1, sessionID: 'ses_defaultArg' },
+			{ sessionID: 'ses_realCtxAbc123', directory: '/fake' },
 		);
-		expect(observedSessionID).toBe('real-session-abc123');
+		expect(observedSessionID).toBe('ses_realCtxAbc123');
 	});
 
 	test('falls back to args.sessionID when ctx is missing', async () => {
@@ -660,10 +660,10 @@ describe('epic_decide_phase tool — ctx.sessionID precedence (Fix B)', () => {
 		};
 		// ctx with no sessionID — must use args.sessionID.
 		await def.execute(
-			{ phase: 1, sessionID: 'from-args' },
+			{ phase: 1, sessionID: 'ses_fromArgs' },
 			{ directory: '/fake' },
 		);
-		expect(observedSessionID).toBe('from-args');
+		expect(observedSessionID).toBe('ses_fromArgs');
 	});
 });
 

--- a/tests/unit/turbo/lean/worktree.test.ts
+++ b/tests/unit/turbo/lean/worktree.test.ts
@@ -87,7 +87,7 @@ afterEach(() => {
 describe('provisionWorktree', () => {
 	const fakeDir = 'C:\\project-root';
 	const fakeLaneId = 'lane-1';
-	const fakeSessionId = 'session-abc';
+	const fakeSessionId = 'ses_abc';
 	const fakeConfig = {};
 
 	test('creates worktree with correct branch name and returns worktreePath + branchName', async () => {
@@ -106,7 +106,7 @@ describe('provisionWorktree', () => {
 
 		expect(result).toEqual({
 			worktreePath: expect.stringContaining('swarm-worktrees'),
-			branchName: 'swarm-lane/session-abc/lane-1',
+			branchName: 'swarm-lane/ses_abc/lane-1',
 		} as Record<string, string>);
 	});
 
@@ -178,7 +178,7 @@ describe('provisionWorktree', () => {
 	});
 
 	test('returns error when branch already exists in an active worktree', async () => {
-		const branchName = 'swarm-lane/session-abc/lane-1';
+		const branchName = 'swarm-lane/ses_abc/lane-1';
 		const worktreeList = `worktree C:\\active-worktree
 HEAD abc123
 branch refs/heads/${branchName}
@@ -202,7 +202,7 @@ branch refs/heads/${branchName}
 
 		expect(result).toEqual({
 			error:
-				'Branch already exists and worktree is active: swarm-lane/session-abc/lane-1 (owned by another session)',
+				'Branch already exists and worktree is active: swarm-lane/ses_abc/lane-1 (owned by another session)',
 		});
 	});
 
@@ -232,7 +232,7 @@ branch refs/heads/${branchName}
 // ---------------------------------------------------------------------------
 
 describe('removeWorktree', () => {
-	const fakeWorktreePath = 'C:\\worktrees\\session-abc\\lane-1';
+	const fakeWorktreePath = 'C:\\worktrees\\ses_abc\\lane-1';
 	const fakeProjectRoot = 'C:\\project-root';
 
 	test('returns { success: true } when removal succeeds', async () => {
@@ -328,7 +328,7 @@ describe('removeWorktree', () => {
 // ---------------------------------------------------------------------------
 
 describe('isCleanWorktree', () => {
-	const fakePath = 'C:\\worktrees\\session-abc\\lane-1';
+	const fakePath = 'C:\\worktrees\\ses_abc\\lane-1';
 
 	test('returns true when both git status --porcelain and git ls-files return empty', async () => {
 		stubSpawn(0, '', ''); // used for both Promise.all calls (same stub, both get empty)
@@ -381,7 +381,7 @@ describe('isCleanWorktree', () => {
 // ---------------------------------------------------------------------------
 
 describe('autoCommitDirty', () => {
-	const fakePath = 'C:\\worktrees\\session-abc\\lane-1';
+	const fakePath = 'C:\\worktrees\\ses_abc\\lane-1';
 
 	test('returns { committed: true, message } on successful commit', async () => {
 		// git add succeeds, git commit succeeds
@@ -447,7 +447,7 @@ describe('autoCommitDirty', () => {
 // ---------------------------------------------------------------------------
 
 describe('cleanUntrackedFiles', () => {
-	const fakePath = 'C:\\worktrees\\session-abc\\lane-1';
+	const fakePath = 'C:\\worktrees\\ses_abc\\lane-1';
 
 	beforeEach(() => {
 		clearDeferredWarnings();
@@ -875,7 +875,7 @@ describe('shortenWorktreePath', () => {
 describe('provisionWorktree — path budget (Windows)', () => {
 	const fakeDir = 'C:\\project-root';
 	const fakeLaneId = 'lane-1';
-	const fakeSessionId = 'session-abc';
+	const fakeSessionId = 'ses_abcabcd'; // length load-bearing: see checkPathBudget
 
 	beforeEach(() => {
 		clearDeferredWarnings();
@@ -983,7 +983,7 @@ describe('_internals.bunSpawn', () => {
 describe('provisionWorktree deps_strategy', () => {
 	const fakeDir = 'C:\\project-root';
 	const fakeLaneId = 'lane-deps';
-	const fakeSessionId = 'sess-deps';
+	const fakeSessionId = 'ses_deps';
 
 	beforeEach(() => {
 		// Always succeed git ops for these tests

--- a/tests/unit/worktree/core.deps-strategy.integration.test.ts
+++ b/tests/unit/worktree/core.deps-strategy.integration.test.ts
@@ -147,7 +147,7 @@ describe('SC-101: provisionWorktree deps_strategy=copy (real fs)', () => {
 		]);
 		currentTestDirs = { hostDir, cleanup };
 
-		const result = await provisionWorktree(hostDir, 'lane-copy', 'sess-copy', {
+		const result = await provisionWorktree(hostDir, 'lane-copy', 'ses_copy', {
 			purpose: 'lane',
 			branchStyle: 'legacy-lane',
 			depsStrategy: 'copy',
@@ -193,7 +193,7 @@ describe('SC-101: provisionWorktree deps_strategy=copy (real fs)', () => {
 		const result = await provisionWorktree(
 			hostDir,
 			'lane-copy-missing',
-			'sess-copy-missing',
+			'ses_copyMissing',
 			{
 				purpose: 'lane',
 				branchStyle: 'legacy-lane',
@@ -228,16 +228,11 @@ describe('SC-102: provisionWorktree deps_strategy=link (real fs)', () => {
 			]);
 			currentTestDirs = { hostDir, cleanup };
 
-			const result = await provisionWorktree(
-				hostDir,
-				'lane-link',
-				'sess-link',
-				{
-					purpose: 'lane',
-					branchStyle: 'legacy-lane',
-					depsStrategy: 'link',
-				},
-			);
+			const result = await provisionWorktree(hostDir, 'lane-link', 'ses_link', {
+				purpose: 'lane',
+				branchStyle: 'legacy-lane',
+				depsStrategy: 'link',
+			});
 
 			expect(result).toHaveProperty('worktreePath');
 			const wtPath = (result as { worktreePath: string }).worktreePath;
@@ -263,7 +258,7 @@ describe('SC-102: provisionWorktree deps_strategy=link (real fs)', () => {
 		const result = await provisionWorktree(
 			hostDir,
 			'lane-link-missing',
-			'sess-link-missing',
+			'ses_linkMissing',
 			{
 				purpose: 'lane',
 				branchStyle: 'legacy-lane',
@@ -306,16 +301,11 @@ describe('SC-103: provisionWorktree missing host node_modules — no silent no-o
 		const { hostDir, cleanup } = setupRealGitRepo('sc103-copy-');
 		currentTestDirs = { hostDir, cleanup };
 
-		const result = await provisionWorktree(
-			hostDir,
-			'lane-sc103',
-			'sess-sc103',
-			{
-				purpose: 'lane',
-				branchStyle: 'legacy-lane',
-				depsStrategy: 'copy',
-			},
-		);
+		const result = await provisionWorktree(hostDir, 'lane-sc103', 'ses_sc103', {
+			purpose: 'lane',
+			branchStyle: 'legacy-lane',
+			depsStrategy: 'copy',
+		});
 
 		expect(result).toHaveProperty('error');
 		expect((result as { error: string }).error).toContain(
@@ -329,7 +319,7 @@ describe('SC-103: provisionWorktree missing host node_modules — no silent no-o
 		// Use computed path since result.worktreePath may be undefined when
 		// checkPathBudget fails before worktree creation.
 		const laneNm = path.join(
-			expectedWorktreePath(hostDir, 'lane-sc103', 'sess-sc103'),
+			expectedWorktreePath(hostDir, 'lane-sc103', 'ses_sc103'),
 			'node_modules',
 		);
 		expect(
@@ -345,7 +335,7 @@ describe('SC-103: provisionWorktree missing host node_modules — no silent no-o
 		const result = await provisionWorktree(
 			hostDir,
 			'lane-sc103-link',
-			'sess-sc103-link',
+			'ses_sc103link',
 			{
 				purpose: 'lane',
 				branchStyle: 'legacy-lane',
@@ -361,7 +351,7 @@ describe('SC-103: provisionWorktree missing host node_modules — no silent no-o
 
 		// No lane node_modules symlink should have been created
 		const laneNm = path.join(
-			expectedWorktreePath(hostDir, 'lane-sc103-link', 'sess-sc103-link'),
+			expectedWorktreePath(hostDir, 'lane-sc103-link', 'ses_sc103link'),
 			'node_modules',
 		);
 		expect(
@@ -391,7 +381,7 @@ describe('Lean adapter provisionWorktree — deps_strategy passthrough', () => {
 		const result = await leanProvision(
 			hostDir,
 			'lane-lean-copy',
-			'sess-lean-copy',
+			'ses_leanCopy',
 			{ deps_strategy: 'copy' } as any, // LeanTurboConfig shape
 		);
 
@@ -420,7 +410,7 @@ describe('Lean adapter provisionWorktree — deps_strategy passthrough', () => {
 		const result = await leanProvision(
 			hostDir,
 			'lane-lean-link',
-			'sess-lean-link',
+			'ses_leanLink',
 			{ deps_strategy: 'link' } as any,
 		);
 

--- a/tests/unit/worktree/provision-lane-recognisability.test.ts
+++ b/tests/unit/worktree/provision-lane-recognisability.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Structural guard: a lane whose branch the recogniser cannot match must never
+ * be provisioned.
+ *
+ * Lane permission scoping identifies a lane by its BRANCH
+ * (`src/config/lane-context.ts` -> `matchSwarmLaneBranch`). If a worktree is
+ * created whose branch falls outside that grammar, detection returns "not a
+ * lane", no permissions are pre-resolved, and the first `external_directory`
+ * request in that lane parks forever on a deferred that no TUI can answer — the
+ * original hang, reintroduced silently.
+ *
+ * The realistic source is an unvalidated session id: tool arguments are
+ * LLM-supplied (`sessionID: z.string()`), and the host's own `SessionID` brand
+ * is only `isStartsWith("ses")`, so a value such as `ses-run-1` passes the host
+ * and reaches `buildSwarmBranchName` intact. Asserting at the provisioning
+ * boundary makes the defect unreachable regardless of where the id came from —
+ * which is what the guardrail is supposed to guarantee.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import {
+	buildSwarmBranchName,
+	matchSwarmLaneBranch,
+} from '../../../src/config/swarm-branch';
+import { _internals, provisionWorktree } from '../../../src/worktree/core';
+import { createSafeTestDir } from '../../helpers/safe-test-dir';
+
+let dir: string;
+let cleanup: () => void;
+let spawnCalls: number;
+const realSpawn = _internals.bunSpawn;
+
+beforeEach(() => {
+	({ dir, cleanup } = createSafeTestDir('provision-guard-'));
+	spawnCalls = 0;
+	// Count subprocess attempts so we can prove the guard fires BEFORE any git
+	// work — a late rejection would already have created a branch/worktree.
+	_internals.bunSpawn = ((...args: unknown[]) => {
+		spawnCalls += 1;
+		return (realSpawn as (...a: unknown[]) => unknown)(...args);
+	}) as typeof _internals.bunSpawn;
+});
+
+afterEach(() => {
+	_internals.bunSpawn = realSpawn;
+	cleanup();
+});
+
+describe('provisionWorktree refuses unrecognisable lanes', () => {
+	test.each([
+		// The exact reproduced case: passes the host `ses` brand, fails the grammar.
+		['ses-run-1'],
+		['phase-3'],
+		['session123'],
+		['SES_abc'],
+		['ses_'],
+		['ses_ab/cd'],
+		[''],
+	])('rejects sessionId %p with an actionable error', async (sessionId) => {
+		const result = await provisionWorktree(dir, 'lane-1', sessionId, {
+			purpose: 'lane',
+		});
+		expect(result).toHaveProperty('error');
+		const message = (result as { error: string }).error;
+		expect(message).toContain('does not match the swarm lane grammar');
+		// Actionable: names the offending value and the required shape.
+		expect(message).toContain(sessionId);
+		expect(message).toContain('ses_');
+		// Fired before any git subprocess ran.
+		expect(spawnCalls).toBe(0);
+		// And nothing was created on disk.
+		expect(fs.readdirSync(dir)).toEqual([]);
+	});
+
+	test('rejects an execution-unit id that is not a single path segment', async () => {
+		const result = await provisionWorktree(dir, 'a/b', 'ses_abc', {
+			purpose: 'lane',
+		});
+		expect(result).toHaveProperty('error');
+		expect(spawnCalls).toBe(0);
+	});
+
+	test('the guard is exactly the recogniser (no second, drifting rule)', () => {
+		// Anything the guard would reject is precisely what detection cannot match.
+		for (const sessionId of ['ses-run-1', 'phase-3', 'ses_ok']) {
+			const branch = buildSwarmBranchName(sessionId, 'lane-1', 'lane', false);
+			const recognised = matchSwarmLaneBranch(branch) !== undefined;
+			expect(recognised).toBe(sessionId === 'ses_ok');
+		}
+	});
+});

--- a/tests/unit/worktree/provision-worktree.adversarial.test.ts
+++ b/tests/unit/worktree/provision-worktree.adversarial.test.ts
@@ -117,7 +117,7 @@ describe('provisionWorktree — adversarial (FR-004)', () => {
 		const sharedWtParent = path.join(
 			os.tmpdir(),
 			'.swarm-worktrees',
-			'parent-session',
+			'ses_parentSession',
 		);
 		fs.rmSync(sharedWtParent, { recursive: true, force: true });
 		origBunSpawn = worktreeInternals.bunSpawn;
@@ -138,7 +138,7 @@ describe('provisionWorktree — adversarial (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/A1';
+		const branchName = 'swarm/lane/ses_parentSession/A1';
 
 		// Create the branch and commit (--allow-empty doesn't touch files)
 		await runGit(['checkout', '-b', branchName], repoDir);
@@ -185,7 +185,7 @@ describe('provisionWorktree — adversarial (FR-004)', () => {
 		expect(listResult.stdout).toContain(branchName);
 
 		// Now call provisionWorktree for the SAME branch — should ERROR
-		const result = await provisionWorktree(repoDir, 'A1', 'parent-session', {
+		const result = await provisionWorktree(repoDir, 'A1', 'ses_parentSession', {
 			purpose: 'lane',
 		});
 
@@ -209,7 +209,7 @@ describe('provisionWorktree — adversarial (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/A2';
+		const branchName = 'swarm/lane/ses_parentSession/A2';
 		await runGit(['checkout', '-b', branchName], repoDir);
 		await runGit(['commit', '--allow-empty', '-m', 'commit'], repoDir);
 		await runGit(['checkout', 'main'], repoDir);
@@ -230,7 +230,7 @@ describe('provisionWorktree — adversarial (FR-004)', () => {
 			return origBunSpawn(args, _opts as Parameters<typeof bunSpawn>[1]);
 		});
 
-		const result = await provisionWorktree(repoDir, 'A2', 'parent-session', {
+		const result = await provisionWorktree(repoDir, 'A2', 'ses_parentSession', {
 			purpose: 'lane',
 		});
 
@@ -258,7 +258,7 @@ describe('provisionWorktree — adversarial (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/A3';
+		const branchName = 'swarm/lane/ses_parentSession/A3';
 		await runGit(['checkout', '-b', branchName], repoDir);
 		await runGit(['commit', '--allow-empty', '-m', 'commit'], repoDir);
 		await runGit(['checkout', 'main'], repoDir);
@@ -285,7 +285,7 @@ branch refs/heads/main
 			return origBunSpawn(args, _opts as Parameters<typeof bunSpawn>[1]);
 		});
 
-		const result = await provisionWorktree(repoDir, 'A3', 'parent-session', {
+		const result = await provisionWorktree(repoDir, 'A3', 'ses_parentSession', {
 			purpose: 'lane',
 		});
 
@@ -307,7 +307,7 @@ branch refs/heads/main
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/A4';
+		const branchName = 'swarm/lane/ses_parentSession/A4';
 		await runGit(['checkout', '-b', branchName], repoDir);
 		await runGit(['commit', '--allow-empty', '-m', 'commit'], repoDir);
 		await runGit(['checkout', 'main'], repoDir);
@@ -325,7 +325,7 @@ branch refs/heads/main
 			return origBunSpawn(args, _opts as Parameters<typeof bunSpawn>[1]);
 		});
 
-		const result = await provisionWorktree(repoDir, 'A4', 'parent-session', {
+		const result = await provisionWorktree(repoDir, 'A4', 'ses_parentSession', {
 			purpose: 'lane',
 		});
 
@@ -349,7 +349,7 @@ branch refs/heads/main
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/A5';
+		const branchName = 'swarm/lane/ses_parentSession/A5';
 		const worktreePath = path.join(
 			os.tmpdir(),
 			'worktree-A5-active-' + Math.random().toString(36).slice(2),
@@ -359,21 +359,36 @@ branch refs/heads/main
 		await createRealWorktree(repoDir, branchName, worktreePath);
 
 		// 1. Default call with active branch → must ERROR
-		const result1 = await provisionWorktree(repoDir, 'A5', 'parent-session', {
-			purpose: 'lane',
-		});
+		const result1 = await provisionWorktree(
+			repoDir,
+			'A5',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+			},
+		);
 
 		// 2. Same branch name but explicit worktreeDir (collision still detected via branch check)
-		const result2 = await provisionWorktree(repoDir, 'A5', 'parent-session', {
-			purpose: 'lane',
-			worktreeDir: path.join(os.tmpdir(), 'worktree-A5-explicit'),
-		});
+		const result2 = await provisionWorktree(
+			repoDir,
+			'A5',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+				worktreeDir: path.join(os.tmpdir(), 'worktree-A5-explicit'),
+			},
+		);
 
 		// 3. Same branch + mergeStrategy option (no bypass)
-		const result3 = await provisionWorktree(repoDir, 'A5', 'parent-session', {
-			purpose: 'lane',
-			mergeStrategy: 'rebase',
-		});
+		const result3 = await provisionWorktree(
+			repoDir,
+			'A5',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+				mergeStrategy: 'rebase',
+			},
+		);
 
 		// All three must return errors — no force-adopt bypass exists
 		expect(result1).toHaveProperty('error');

--- a/tests/unit/worktree/provision-worktree.test.ts
+++ b/tests/unit/worktree/provision-worktree.test.ts
@@ -118,11 +118,11 @@ describe('provisionWorktree — verification (FR-004)', () => {
 
 	beforeEach(() => {
 		// Clean the shared default worktree parent dir to prevent cross-test pollution
-		// Tests use the same default path: os.tmpdir()/.swarm-worktrees/parent-session/<id>
+		// Tests use the same default path: os.tmpdir()/.swarm-worktrees/ses_parentSession/<id>
 		const sharedWtParent = path.join(
 			os.tmpdir(),
 			'.swarm-worktrees',
-			'parent-session',
+			'ses_parentSession',
 		);
 		fs.rmSync(sharedWtParent, { recursive: true, force: true });
 		origBunSpawn = worktreeInternals.bunSpawn;
@@ -138,15 +138,20 @@ describe('provisionWorktree — verification (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const result = await provisionWorktree(repoDir, '1.1', 'parent-session', {
-			purpose: 'lane',
-		});
+		const result = await provisionWorktree(
+			repoDir,
+			'1.1',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+			},
+		);
 
 		// Fail with the actual error message if provisioning failed
 		expect(result).toHaveProperty('worktreePath');
 		expect(result).toHaveProperty('branchName');
 		const handle = result as { worktreePath: string; branchName: string };
-		expect(handle.branchName).toBe('swarm/lane/parent-session/1.1');
+		expect(handle.branchName).toBe('swarm/lane/ses_parentSession/1.1');
 		const listResult = await runGit(
 			['worktree', 'list', '--porcelain'],
 			repoDir,
@@ -181,16 +186,21 @@ describe('provisionWorktree — verification (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/2.1';
+		const branchName = 'swarm/lane/ses_parentSession/2.1';
 
 		// Create the branch (but no worktree), then switch back to main so it is
 		// stale but has no commits ahead of HEAD.
 		await runGit(['checkout', '-b', branchName], repoDir);
 		await runGit(['checkout', 'main'], repoDir);
 
-		const result = await provisionWorktree(repoDir, '2.1', 'parent-session', {
-			purpose: 'lane',
-		});
+		const result = await provisionWorktree(
+			repoDir,
+			'2.1',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+			},
+		);
 
 		// Should succeed and recreate the branch from the current HEAD, not adopt
 		// the stale branch state.
@@ -222,14 +232,19 @@ describe('provisionWorktree — verification (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/2.1';
+		const branchName = 'swarm/lane/ses_parentSession/2.1';
 		await runGit(['checkout', '-b', branchName], repoDir);
 		await runGit(['commit', '--allow-empty', '-m', 'stale commit'], repoDir);
 		await runGit(['checkout', 'main'], repoDir);
 
-		const result = await provisionWorktree(repoDir, '2.1', 'parent-session', {
-			purpose: 'lane',
-		});
+		const result = await provisionWorktree(
+			repoDir,
+			'2.1',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+			},
+		);
 
 		expect(result).toEqual({
 			error: `Branch already exists and has unmerged commits: ${branchName}`,
@@ -248,20 +263,25 @@ describe('provisionWorktree — verification (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/3.1';
+		const branchName = 'swarm/lane/ses_parentSession/3.1';
 		const worktreePath = path.join(
 			repoDir,
 			'.swarm-worktrees',
-			'parent-session',
+			'ses_parentSession',
 			'3.1',
 		);
 
 		// Create a REAL worktree with this branch (active collision)
 		await createRealWorktree(repoDir, branchName, worktreePath);
 
-		const result = await provisionWorktree(repoDir, '3.1', 'parent-session', {
-			purpose: 'lane',
-		});
+		const result = await provisionWorktree(
+			repoDir,
+			'3.1',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+			},
+		);
 
 		// Should return error (active collision)
 		expect(result).toHaveProperty('error');
@@ -283,7 +303,7 @@ describe('provisionWorktree — verification (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/4.1';
+		const branchName = 'swarm/lane/ses_parentSession/4.1';
 
 		// Create the branch (no worktree), then manually register a worktree at
 		// the EXPECTED path (simulating a previously created worktree that's now gone
@@ -297,7 +317,7 @@ describe('provisionWorktree — verification (FR-004)', () => {
 		const expectedPath = path.join(
 			path.dirname(repoDir),
 			'.swarm-worktrees',
-			'parent-session',
+			'ses_parentSession',
 			'4.1',
 		);
 		fs.mkdirSync(path.dirname(expectedPath), { recursive: true });
@@ -313,9 +333,14 @@ describe('provisionWorktree — verification (FR-004)', () => {
 			fs.writeFileSync(path.join(expectedPath, 'dirty.txt'), 'do not delete');
 		}
 
-		const result = await provisionWorktree(repoDir, '4.1', 'parent-session', {
-			purpose: 'lane',
-		});
+		const result = await provisionWorktree(
+			repoDir,
+			'4.1',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+			},
+		);
 
 		// Should return error because same-task cleanup must not delete dirty work.
 		expect(result).toHaveProperty('error');
@@ -341,7 +366,7 @@ describe('provisionWorktree — verification (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/5.1';
+		const branchName = 'swarm/lane/ses_parentSession/5.1';
 
 		// Create the branch so provisionWorktree enters the reconciliation branch
 		await runGit(['checkout', '-b', branchName], repoDir);
@@ -367,9 +392,14 @@ describe('provisionWorktree — verification (FR-004)', () => {
 			return origBunSpawn(args, _opts as Parameters<typeof bunSpawn>[1]);
 		});
 
-		const result = await provisionWorktree(repoDir, '5.1', 'parent-session', {
-			purpose: 'lane',
-		});
+		const result = await provisionWorktree(
+			repoDir,
+			'5.1',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+			},
+		);
 
 		// Should return error (fail-safe, never adopt)
 		expect(result).toHaveProperty('error');
@@ -394,7 +424,7 @@ describe('provisionWorktree — verification (FR-004)', () => {
 		fs.mkdirSync(repoDir, { recursive: true });
 		await initGitRepo(repoDir);
 
-		const branchName = 'swarm/lane/parent-session/6.1';
+		const branchName = 'swarm/lane/ses_parentSession/6.1';
 
 		// Create the branch so we enter the reconciliation branch
 		await runGit(['checkout', '-b', branchName], repoDir);
@@ -416,9 +446,14 @@ describe('provisionWorktree — verification (FR-004)', () => {
 			return origBunSpawn(args, _opts as Parameters<typeof bunSpawn>[1]);
 		});
 
-		const result = await provisionWorktree(repoDir, '6.1', 'parent-session', {
-			purpose: 'lane',
-		});
+		const result = await provisionWorktree(
+			repoDir,
+			'6.1',
+			'ses_parentSession',
+			{
+				purpose: 'lane',
+			},
+		);
 
 		expect(result).toHaveProperty('error');
 		if ('error' in result) {


### PR DESCRIPTION
Closes #2013

## Summary

OpenCode partitions **all** permission state by *directory*. Verified verbatim in the reporter's own binary (`C:\OpenCode\opencode.exe`, opencode 1.18.10), `InstanceState` at offset 103271994:

```js
t$ = W.map(A2, ($) => $.directory);        // Permission.state cache key IS the directory
```

Each directory gets its own `{ pending: new Map, approved: [] }`. opencode-swarm creates worktree-lane subagent sessions bound to a **new** directory (`src/hooks/delegation-gate/worktree-isolation.ts:929`, `src/turbo/lean/runner.ts:768`), so every lane got a brand-new, empty permission universe:

- every prior "Allow always" was absent — `approved` started empty;
- both reply routes select the instance from the `directory` **query parameter**, and the client replies with **its own** directory (offset 97764366), so a reply to a lane's prompt resolved the wrong `pending` map and 404'd;
- `Permission.ask` awaits an **untimed** deferred (offset 102984994), so the asking fiber never settled.

The reporter's log proves both halves. Aggregated over `opencode.log`, `evaluated permission=external_directory` by pattern: `C:\Users\Brett\AppData\Local\Temp\*` was **asked 108 times despite 1052 allows**; the path in the screenshot, `C:\Users\Brett\.claude\skills\engineering-conventions\*`, was asked once and **never allowed**. The lane session from that report asked at 06:24:39 and then emitted nothing for **52 minutes**.

**The fix.** Because the plugin `permission.ask` hook is declared but never invoked by this host (`Plugin.trigger` dispatches 16 literal hook names; `permission.ask` is not among them), the only available lever is the `config` hook. Lane instances now pre-grant a narrow, justified `external_directory` allowlist and deny everything else **terminally**, so a lane can fail fast but can never hang.

- **Lane detection** (`src/config/lane-context.ts`, `src/config/swarm-branch.ts`) — a directory is a lane only if `<gitDir>/HEAD` carries the full swarm branch grammar (`swarm/<purpose>/<sessionId>/<id>` or `swarm-lane/<sessionId>/<id>`, session segment `ses_[A-Za-z0-9]+`), or its path matches the full provisioned shape. Producer and recogniser derive from one definition and cannot drift.
- **Allowlist** (`src/config/lane-permissions.ts`) — parent project, the lane, `<data>/plans`, host config dirs, OS temp subtrees, and every skill root the host itself discovers (both `{skill,skills}` spellings, plus `skills.paths`, and — only when `skills.urls` is configured — the URL-skill cache root).
- **Terminal deny** for everything else, with a user `ask` coerced to `deny` **inside lanes only** — an `ask` in a lane has no counterparty and would deadlock. Explicit user `allow`/`deny` still win.
- **Structural guard** (`src/worktree/core.ts:595`) — `provisionWorktree` hard-fails, before any side effect, if the branch it is about to create is not one the recogniser will match.

Also fixed from the same report:

- **"you also cannot exit the app"** — `PlanSyncWorker` and `PrMonitorWorker` held un-`unref`'d intervals that pinned the event loop open, and `PlanSyncWorker.stop()`/`dispose()` were **unreachable production code** (a block-scoped `const` never referenced by `cleanupAutomation`).
- **`src/agents/index.ts`** — agent `permission` was *assigned* rather than merged, silently discarding any permission block an agent definition declared.

Two host-side co-factors cannot be fixed from this repo and are documented for an upstream report: the dead `permission.ask` hook, and the client replying with its own directory.

## Invariant audit

- **1 (plugin init): touched** — `applyLanePermissions` runs in the `config` hook. No subprocess (detection reads git's files directly rather than spawning `git rev-parse`), no network, no unbounded scan: ≤40 `statSync` + ≤3 `readFileSync`, cached per directory (bounded 256, FIFO). Measured init cost **0.92 ms ordinary session / 6.77 ms lane** cold; non-lane instances return before building anything. `node scripts/repro-704.mjs` T1 **214.8–237.6 ms** against the ~400 ms deadline across rounds. Retry on transient I/O is bounded (3 attempts, ~32 ms worst case on win32) and only on the error path.
- **2 (runtime portability): touched** — `src/index.ts` changed. `bun run build` rc=0; `node --input-type=module -e "await import('./dist/index.js')"` rc=0; `bundle-portability.test.ts` 10 pass, `bundle-plugin-shape.test.ts` 2 pass. Diff scan confirms **no** new `bun:` imports and **no** `Bun.*` outside `bun-compat` (`git diff origin/main..HEAD -- src/ | grep -E "from ['\"]bun:|require\(['\"]bun:|Bun\."` → empty). `dist/` not staged — the commit is exactly 47 files, verified.
- **3 (subprocesses): not touched** — `git diff origin/main..HEAD -- src/ | grep -E "^\+.*\b(bunSpawn|spawn|spawnSync|execFile)\s*\("` → empty. The pre-existing `_internals.bunSpawn` sites in `src/worktree/core.ts:263,341` are unmodified. Lane detection deliberately reads `.git`/`HEAD`/`commondir` as files rather than spawning, to keep invariant 1 intact.
- **4 (.swarm containment): touched** — `recordLanePermissionEvent` writes `.swarm/events.jsonl`. It is anchored on `lane.lanePath`, not `ctx.directory`, on **both** the applied and skipped paths (`src/config/lane-permissions.ts:878,929`), so an instance bound below a lane root cannot create `.swarm/` under a source subdirectory. Regression-tested in `lane-permissions-config.test.ts` (nested-applied, nested-off); both fail when the anchor is reverted.
- **5 (plan durability): not touched** — no plan schema, ledger, projection, or status-shape change. The `plan-sync-worker.ts` edit is lifecycle only (`.unref()` + reachable `stop()`).
- **6 (test_runner safety): not touched** — the OpenCode `test_runner` tool was not used. All validation ran as shell commands with per-file isolation.
- **7 (test writing): touched** — 11 new test files, all under the 500-line cap (largest 429). Over-cap files touched are at **ratchet delta 0** (`delegation-gate-worktree-isolation.resolution.test.ts` 540→540, `turbo/lean/worktree.test.ts` 1143→1143). `scripts/check-test-file-cap.sh` rc=0. No `mock.module` added; the shared fixture `tests/helpers/lane-permissions-fixture.ts` is pure data, proven leak-free by a single-process co-run of all six lane suites yielding 139 = the exact sum of the individual runs. `_internals` DI seams used throughout.
- **8 (session state): touched** — `laneContextCache` is bounded at 256 with evict-before-insert FIFO (asserted in `lane-context.test.ts`). `planSyncWorker` hoisted from a block-scoped `const` to function scope and stopped in `cleanupAutomation` alongside `prMonitorWorker`.
- **9 (guardrails/retry): touched** — new hard-fail guard in `provisionWorktree` (fixed rule, no retry); detection retry bounded by a fixed 3-attempt counter with sleep only between attempts, never unbounded, and fail-open (an exhausted retry reports "not a lane" and mutates nothing).
- **10 (chat/system msg): not touched** — no `chat.message`, `chat.params`, or system-transform changes.
- **11 (tool registration): not touched** — no new tools, commands, or agent-map entries. `bun run scripts/check-tool-registration.ts` rc=0 (coherence maintained).
- **12 (release/cache): touched** — added `docs/releases/pending/worktree-lane-permission-scoping.md`. `package.json` version, `CHANGELOG.md`, and `.release-please-manifest.json` untouched.

## Test plan

- [x] `bun run build` — rc=0; `node --input-type=module -e "await import('./dist/index.js')"` — rc=0
- [x] `node scripts/repro-704.mjs` — rc=0, T1 within the ~400 ms deadline
- [x] `bun run typecheck` — rc=0
- [x] `bun run lint:ci` — rc=0
- [x] `bun run scripts/check-tool-registration.ts` — rc=0
- [x] `bash scripts/check-mock-cleanup.sh` — rc=0
- [x] `bash scripts/check-invariants.sh` — rc=0
- [x] `bash scripts/check-cross-contamination.sh` — rc=0
- [x] `bash scripts/check-test-clock.sh` — rc=0, 0 blocking violations
- [x] `bash scripts/check-test-file-cap.sh` — rc=0, 0 new-file and 0 ratchet violations
- [x] `bun run test:unit:ci <148 blast-radius files>` — rc=0
- [x] `bun test tests/security` / `tests/adversarial` / `tests/smoke` — all rc=0
- [x] **Derived blast-radius sweep** — 148 files (every test referencing any changed module or constrained symbol, derived mechanically rather than hand-picked), each run individually: **148/148 rc=0**
- [x] `bun test tests/integration ./test` — see "Pre-existing failures" below

### Pre-existing failures

The bulk integration run reports failures on this branch **and on clean `origin/main`**, from the documented `mock.module` cross-file pollution in Bun's shared test-runner process (AGENTS.md invariant 7). Proven with a detached worktree at `origin/main`:

| | clean `origin/main` | this branch |
|---|---|---|
| pass | 749 | 749 |
| fail | 214 | 215 |
| tests | 963 | 964 |

Identical pass counts. The +1 test / +1 fail is the reachability test added to `tests/integration/plan-sync-init.test.ts`, which passes **14/14 in isolation** (13/13 on main). Nothing previously passing regressed.

### Known gaps

1. **No genuine Linux or macOS run.** All local results are from a Windows host, and forcing `process.platform` does **not** rebind `node:path` — POSIX path semantics were never exercised locally. The CI ubuntu leg is the only real check. This technique gap already hid one real bug during review.
2. POSIX case-sensitivity branches in `matchSwarmLanePath` and `push()` are read-verified only; failure direction is a safe false negative.
3. **No live lane exercised end to end** — the `config` hook was invoked for real and detection ran against real git objects, but no OpenCode instance was booted inside a lane and observed not to hang.
4. Hook-before-`Agent.state` ordering is an empirical property, not a contract: both read the same InstanceState-cached config object and the two mutations are adjacent synchronous statements with no `await`, so no ordering can split them — but the Agent layer's deps contain no Plugin node, so there is no static guarantee.
5. The allowlist was verified against a transcribed host model (primitives character-verified against the binary), not a running host. Gaps 1 and 5 **compound**.
6. `Atomics.wait` retry timing measured only on Windows (~32 ms worst case vs 10 ms nominal).
7. The transient-retry path was exercised with an **injected** `EMFILE`, not a real one.
8. The URL-sourced skill cache (`$XDG_CACHE_HOME/opencode/skills`, default `~/.cache/opencode/skills`) is
    granted **only when `skills.urls` is configured**, and only at the root — the host's per-URL leaf layout
    uses `Bun.hash`, which cannot be used here without breaking Node-ESM loadability (invariant 2). The grant
    is therefore a scoped superset of the host's per-directory base allow, and because `external_directory`
    has no read/write split, a lane can write there. Documented with the cross-session consequence and the
    `lane_permissions: "deny"` opt-out.
9. `config.references` directories remain a known narrowing, disclosed with a remedy.
10. `Config.directories()` intermediate ancestors are not covered for a nested-instance lane.
11. **Behaviour change:** `provisionWorktree` now hard-fails on a session id outside the `ses_[A-Za-z0-9]+` grammar where it previously provisioned. Judged unreachable in production — its only production caller passes the host-supplied hook session id — and safe if reached.

### Review

Seven Phase 4.5 implementation-review rounds (3 HIGH → 2 HIGH → 2 HIGH → approve-with-fixes → 2 blocking → 2 blocking → **APPROVE**) and two Phase 4.6 critic rounds, both finding **no shipped correctness defect**. 15 mutations across five rounds, all killed.

### Separable concerns found en route (tracked, not deferred)

- **#2007** — `lean_turbo.phase_critic` defaults to `true` but is unsatisfiable.
- **#2009** — evaluation sessions use a foreign directory the lane scoping cannot cover; that path can still hang the same way.
- **#2010** — two pre-existing tests rewrite the tracked `.opencode/opencode-swarm.json`; developer-machine only, invisible on CI.
- **#2018** — `tests/helpers/safe-test-dir.ts` uses non-native `realpathSync`, so the Windows 8.3 short-name
  guarantee its own header claims is false. Fixed locally in this PR; the shared helper (77 consumers) is left
  for a focused change.

## Waivers

None.
